### PR TITLE
message office api now responds with harbor docker registry credentia…

### DIFF
--- a/apps/message-office/internal/app/app.go
+++ b/apps/message-office/internal/app/app.go
@@ -2,9 +2,14 @@ package app
 
 import (
 	"github.com/gofiber/fiber/v2"
+	artifactsv1 "github.com/kloudlite/operator/apis/artifacts/v1"
 	"github.com/kloudlite/operator/grpc-interfaces/grpc/messages"
+	"github.com/kloudlite/operator/pkg/kubectl"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+
 	"kloudlite.io/apps/message-office/internal/app/graph"
 	"kloudlite.io/apps/message-office/internal/app/graph/generated"
 	"kloudlite.io/apps/message-office/internal/domain"
@@ -15,15 +20,25 @@ import (
 	"kloudlite.io/pkg/repos"
 )
 
+type ContainerRegistryGrpcConnection *grpc.ClientConn
+
 var Module = fx.Module("app",
 	redpanda.NewProducerFx[redpanda.Client](),
-	fx.Provide(func(logger logging.Logger, producer redpanda.Producer, ev *env.Env, d domain.Domain) messages.MessageDispatchServiceServer {
+
+	fx.Provide(func(restCfg *rest.Config) (kubectl.ControllerClient, error) {
+		scheme := runtime.NewScheme()
+		artifactsv1.AddToScheme(scheme)
+		return kubectl.NewClientWithScheme(restCfg, scheme)
+	}),
+
+	fx.Provide(func(logger logging.Logger, producer redpanda.Producer, ev *env.Env, d domain.Domain, kControllerCli kubectl.ControllerClient) messages.MessageDispatchServiceServer {
 		return &grpcServer{
-			domain:    d,
-			logger:    logger,
-			producer:  producer,
-			consumers: map[string]redpanda.Consumer{},
-			ev:        ev,
+			domain:           d,
+			logger:           logger,
+			producer:         producer,
+			consumers:        map[string]redpanda.Consumer{},
+			ev:               ev,
+			k8sControllerCli: kControllerCli,
 		}
 	}),
 	fx.Invoke(
@@ -31,6 +46,7 @@ var Module = fx.Module("app",
 			messages.RegisterMessageDispatchServiceServer(server, messageServer)
 		},
 	),
+
 	repos.NewFxMongoRepo[*domain.MessageOfficeToken]("mo_tokens", "mot", domain.MOTokenIndexes),
 	repos.NewFxMongoRepo[*domain.AccessToken]("acc_tokens", "acct", domain.AccessTokenIndexes),
 	fx.Invoke(

--- a/apps/message-office/internal/domain/api.go
+++ b/apps/message-office/internal/domain/api.go
@@ -5,6 +5,6 @@ import "context"
 type Domain interface {
 	GenClusterToken(ctx context.Context, accountName string, clusterName string) (string, error)
 	GetClusterToken(ctx context.Context, accountName string, clusterName string) (string, error)
-	GenAccessToken(ctx context.Context, clusterToken string) (string, error)
+	GenAccessToken(ctx context.Context, clusterToken string) (*AccessToken, error)
 	ValidateAccessToken(ctx context.Context, accessToken, accountName, clusterName string) error
 }

--- a/apps/message-office/internal/domain/entities.go
+++ b/apps/message-office/internal/domain/entities.go
@@ -7,6 +7,7 @@ type MessageOfficeToken struct {
 	AccountName      string `json:"accountName"`
 	ClusterName      string `json:"clusterName"`
 	Token            string `json:"token"`
+	Granted          *bool  `json:"granted,omitempty"`
 }
 
 var MOTokenIndexes = []repos.IndexField{
@@ -32,7 +33,6 @@ type AccessToken struct {
 	ClusterName      string `json:"clusterName"`
 	AccessToken      string `json:"accessToken"`
 }
-
 
 var AccessTokenIndexes = []repos.IndexField{
 	{

--- a/apps/message-office/internal/framework/framework.go
+++ b/apps/message-office/internal/framework/framework.go
@@ -1,7 +1,10 @@
 package framework
 
 import (
+	"github.com/kloudlite/operator/pkg/kubectl"
 	"go.uber.org/fx"
+	"k8s.io/client-go/rest"
+
 	"kloudlite.io/apps/message-office/internal/app"
 	"kloudlite.io/apps/message-office/internal/env"
 	rpc "kloudlite.io/pkg/grpc"
@@ -49,6 +52,11 @@ var Module = fx.Module("framework",
 	}),
 	redpanda.NewClientFx[*fm](),
 	mongoDb.NewMongoClientFx[*fm](),
+
+	fx.Provide(func(restCfg *rest.Config) (*kubectl.YAMLClient, error) {
+		return kubectl.NewYAMLClient(restCfg)
+	}),
+
 	app.Module,
 	rpc.NewGrpcServerFx[*fm](),
 	httpServer.NewHttpServerFx[*fm](),

--- a/apps/message-office/main.go
+++ b/apps/message-office/main.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"go.uber.org/fx"
-	"kloudlite.io/pkg/logging"
+	"k8s.io/client-go/rest"
 
 	env "kloudlite.io/apps/message-office/internal/env"
 	"kloudlite.io/apps/message-office/internal/framework"
+	"kloudlite.io/pkg/k8s"
+	"kloudlite.io/pkg/logging"
 )
 
 func main() {
@@ -30,6 +32,16 @@ func main() {
 				return logging.New(&logging.Options{Name: "message-office", Dev: isDev})
 			},
 		),
+
+		fx.Provide(func() (*rest.Config, error) {
+			if isDev {
+				return &rest.Config{
+					Host: "localhost:8080",
+				}, nil
+			}
+			return k8s.RestInclusterConfig()
+		}),
+
 		// fn.FxErrorHandler(),
 		framework.Module,
 	)


### PR DESCRIPTION
## Description

message office now shared harbor docker registry credentials with agent over GRPC when doing cluster token exchange

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
