### PR TITLE
feat(apps/infra): cloudprovider secret, and aws assume role updates

### DIFF
--- a/.tools/__http__/infra/cloud-provider-secrets.graphql.yml
+++ b/.tools/__http__/infra/cloud-provider-secrets.graphql.yml
@@ -5,43 +5,47 @@ global:
 
   providerNamespace: kl-account-kloudlite-dev
   providerName: aws-creds
+  newProviderName: aws-creds3
+
 ---
 
 label: Create Cloud Provider Secret
 query: |+
   mutation Infra_createProviderSecret($secret: CloudProviderSecretIn!) {
     infra_createProviderSecret(secret: $secret) {
-      data
       id
     }
   }
 variables:
   secret:
     displayName: "{{.providerName}}"
-    cloudProviderName: aws
     metadata:
-      name: "{{.providerName}}"
-    stringData:
-      accessKey: "{{.awsAccessKey}}"
-      accessSecret: "{{.awsAccessSecret}}"
+      name: "{{.newProviderName}}"
+    cloudProviderName: aws
+    aws:
+      awsAccountId: "{{.awsAccountId}}"
+    # stringData:
+    #   accessKey: "{{.awsAccessKey}}"
+    #   accessSecret: "{{.awsAccessSecret}}"
+
 ---
 
 label: Update Cloud Provider Secret
 query: |+
   mutation Infra_updateProviderSecret($secret: CloudProviderSecretIn!) {
     infra_updateProviderSecret(secret: $secret) {
-      data
       id
     }
   }
 variables:
   secret:
+    displayName: "{{.providerName}}"
     metadata:
-      name: "{{.providerSecretName}}"
-    stringData:
-      k1: v1
-      k2: v2
-      k3: v3
+      name: "{{.newProviderName}}"
+    cloudProviderName: aws
+    aws:
+      awsAccountId: "{{.awsAccountId}}"
+
 ---
 
 label: List Provider Secrets
@@ -56,7 +60,11 @@ query: |+
             name
             namespace
           }
-          stringData
+          aws {
+            awsAccountId
+            awsAssumeRoleExternalId
+            awsAssumeRoleRoleARN
+          }
         }
       }
     }
@@ -91,19 +99,20 @@ query: |+
     infra_deleteProviderSecret(secretName: $secretName)
   }
 variables:
-  secretName: "{{.providerName}}"
+  # secretName: "{{.providerName}}"
+  secretName: "{{.newProviderName}}"
 ---
 
 ---
 label: Check AWS Access
 query: |+
-  query Infra_checkAWSAccess($accountId: String!) {
-    infra_checkAwsAccess(accountId: $accountId) {
+  query Infra_checkAWSAccess($cloudproviderName: String!) {
+    infra_checkAwsAccess(cloudproviderName: $cloudproviderName) {
       result
       installationUrl
     }
   }
 variables:
-  accountId: "855999427630"
+  cloudproviderName: "{{.newProviderName}}"
 ---
 

--- a/.tools/__http__/infra/clusters.graphql.yml
+++ b/.tools/__http__/infra/clusters.graphql.yml
@@ -3,7 +3,8 @@ global:
   accountName: kloudlite-dev
   clusterName: sample-cluster
 
-  providerSecretName: "aws-creds"
+  # providerSecretName: "aws-creds"
+  providerSecretName: "aws-creds3"
   providerSecretNamespace: "kl-account-kloudlite-dev"
 
   awsAccountId: "855999427630"
@@ -35,7 +36,6 @@ variables:
         namespace: "{{.providerSecretNamespace}}"
       cloudProvider: aws
       aws:
-        awsAccountId: "{{.awsAccountId}}"
         region: ap-south-1
         k3sMasters:
           instanceType: c6a.large
@@ -125,58 +125,17 @@ variables:
     metadata:
       name: "{{.clusterName}}"
     spec:
-      accountName: "{{.accountName}}"
-      accountId: "{{.accountId}}"
+      cloudflareEnabled: true
+      availabilityMode: dev
       credentialsRef:
         name: "{{.providerSecretName}}"
         namespace: "{{.providerSecretNamespace}}"
-      availabilityMode: HA
       cloudProvider: aws
       aws:
         region: ap-south-1
-        ami: ami-06d146e85d1709abb
-        iamInstanceProfileRole: EC2StorageAccess
-        ec2NodesConfig:
-          master-1:
-            instanceType: c6a.large
-            availabilityZone: ap-south-1a
-            rootVolumeSize: 20
-            role: primary-master
-          master-2:
-            instanceType: c6a.large
-            availabilityZone: ap-south-1b
-            rootVolumeSize: 20
-            role: secondary-master
-          master-3:
-            instanceType: c6a.large
-            availabilityZone: ap-south-1c
-            rootVolumeSize: 20
-            role: secondary-master
-          agent-1:
-            instanceType: c6a.large
-            availabilityZone: ap-south-1c
-            rootVolumeSize: 20
-            role: agent
-        spotSettings:
-          spotFleetTaggingRoleName: aws-ec2-spot-fleet-tagging-role
-        spotNodesConfig:
-          spot-1:
-            vCpu:
-              min: 1
-              max: 2
-            memPerVCpu:
-              min: 2
-              max: 4
-            rootVolumeSize: 50
-          spot-2:
-            vCpu:
-              min: 1
-              max: 2
-            memPerVCpu:
-              min: 2
-              max: 4
-            rootVolumeSize: 50
-      disableSSH: false
+        k3sMasters:
+          instanceType: c6a.large
+          iamInstanceProfileRole: "EC2StorageAccess"
 
 ---
 

--- a/apps/infra/internal/app/app.go
+++ b/apps/infra/internal/app/app.go
@@ -46,7 +46,7 @@ var Module = fx.Module(
 	repos.NewFxMongoRepo[*entities.DomainEntry]("domain_entries", "de", entities.DomainEntryIndices),
 	repos.NewFxMongoRepo[*entities.NodePool]("node_pools", "npool", entities.NodePoolIndices),
 	repos.NewFxMongoRepo[*entities.Node]("node", "node", entities.NodePoolIndices),
-	repos.NewFxMongoRepo[*entities.CloudProviderSecret]("secrets", "scrt", entities.SecretIndices),
+	repos.NewFxMongoRepo[*entities.CloudProviderSecret]("cloud_provider_secrets", "cps", entities.CloudProviderSecretIndices),
 	repos.NewFxMongoRepo[*entities.VPNDevice]("vpn_devices", "vpnd", entities.VPNDeviceIndexes),
 
 	fx.Provide(

--- a/apps/infra/internal/app/gqlgen.yml
+++ b/apps/infra/internal/app/gqlgen.yml
@@ -144,3 +144,5 @@ models:
   Kloudlite__io___pkg___types__SyncStatusAction:
     model: kloudlite.io/pkg/types.SyncAction
 
+  # CheckAwsAccessOutput:
+  #   model: kloudlite.io/apps/infra/internal/domain.AWSAccessValidationOutput

--- a/apps/infra/internal/app/graph/generated/generated.go
+++ b/apps/infra/internal/app/graph/generated/generated.go
@@ -115,22 +115,17 @@ type ComplexityRoot struct {
 	}
 
 	CloudProviderSecret struct {
-		APIVersion        func(childComplexity int) int
 		AccountName       func(childComplexity int) int
+		Aws               func(childComplexity int) int
 		CloudProviderName func(childComplexity int) int
 		CreatedBy         func(childComplexity int) int
 		CreationTime      func(childComplexity int) int
-		Data              func(childComplexity int) int
 		DisplayName       func(childComplexity int) int
 		ID                func(childComplexity int) int
-		Immutable         func(childComplexity int) int
-		Kind              func(childComplexity int) int
 		LastUpdatedBy     func(childComplexity int) int
 		MarkedForDeletion func(childComplexity int) int
 		ObjectMeta        func(childComplexity int) int
 		RecordVersion     func(childComplexity int) int
-		StringData        func(childComplexity int) int
-		Type              func(childComplexity int) int
 		UpdateTime        func(childComplexity int) int
 	}
 
@@ -209,12 +204,10 @@ type ComplexityRoot struct {
 	}
 
 	Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig struct {
-		AwsAccountID                    func(childComplexity int) int
-		AwsAssumeRoleParamExternalIDRef func(childComplexity int) int
-		K3sMasters                      func(childComplexity int) int
-		NodePools                       func(childComplexity int) int
-		Region                          func(childComplexity int) int
-		SpotNodePools                   func(childComplexity int) int
+		K3sMasters    func(childComplexity int) int
+		NodePools     func(childComplexity int) int
+		Region        func(childComplexity int) int
+		SpotNodePools func(childComplexity int) int
 	}
 
 	Github__com___kloudlite___operator___apis___clusters___v1__AWSK3sMastersConfig struct {
@@ -280,6 +273,14 @@ type ComplexityRoot struct {
 		StorageClasses     func(childComplexity int) int
 	}
 
+	Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys struct {
+		KeyAWSAccountID            func(childComplexity int) int
+		KeyAWSAssumeRoleExternalID func(childComplexity int) int
+		KeyAWSAssumeRoleRoleArn    func(childComplexity int) int
+		KeyAccessKey               func(childComplexity int) int
+		KeySecretKey               func(childComplexity int) int
+	}
+
 	Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput struct {
 		KeyK3sAgentJoinToken  func(childComplexity int) int
 		KeyK3sServerJoinToken func(childComplexity int) int
@@ -297,6 +298,7 @@ type ComplexityRoot struct {
 		CloudflareEnabled      func(childComplexity int) int
 		ClusterInternalDNSHost func(childComplexity int) int
 		ClusterTokenRef        func(childComplexity int) int
+		CredentialKeys         func(childComplexity int) int
 		CredentialsRef         func(childComplexity int) int
 		KloudliteRelease       func(childComplexity int) int
 		MessageQueueTopicName  func(childComplexity int) int
@@ -378,6 +380,14 @@ type ComplexityRoot struct {
 
 	Github__com___kloudlite___operator___pkg___raw____json__RawJson struct {
 		RawMessage func(childComplexity int) int
+	}
+
+	Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials struct {
+		AccessKey               func(childComplexity int) int
+		AwsAccountID            func(childComplexity int) int
+		AwsAssumeRoleExternalID func(childComplexity int) int
+		AwsAssumeRoleRoleArn    func(childComplexity int) int
+		SecretKey               func(childComplexity int) int
 	}
 
 	Kloudlite__io___apps___infra___internal___entities__HelmStatusVal struct {
@@ -503,7 +513,7 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		InfraCheckAwsAccess        func(childComplexity int, accountID string) int
+		InfraCheckAwsAccess        func(childComplexity int, cloudproviderName string) int
 		InfraCheckNameAvailability func(childComplexity int, resType domain.ResType, clusterName *string, name string) int
 		InfraGetBYOCCluster        func(childComplexity int, name string) int
 		InfraGetCluster            func(childComplexity int, name string) int
@@ -568,13 +578,13 @@ type BYOCClusterResolver interface {
 	UpdateTime(ctx context.Context, obj *entities.BYOCCluster) (string, error)
 }
 type CloudProviderSecretResolver interface {
+	Aws(ctx context.Context, obj *entities.CloudProviderSecret) (*model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials, error)
+	CloudProviderName(ctx context.Context, obj *entities.CloudProviderSecret) (model.GithubComKloudliteOperatorApisCommonTypesCloudProvider, error)
+
 	CreationTime(ctx context.Context, obj *entities.CloudProviderSecret) (string, error)
-	Data(ctx context.Context, obj *entities.CloudProviderSecret) (map[string]interface{}, error)
 
 	ID(ctx context.Context, obj *entities.CloudProviderSecret) (string, error)
 
-	StringData(ctx context.Context, obj *entities.CloudProviderSecret) (map[string]interface{}, error)
-	Type(ctx context.Context, obj *entities.CloudProviderSecret) (*model.K8sIoAPICoreV1SecretType, error)
 	UpdateTime(ctx context.Context, obj *entities.CloudProviderSecret) (string, error)
 }
 type ClusterResolver interface {
@@ -663,7 +673,7 @@ type QueryResolver interface {
 	InfraGetProviderSecret(ctx context.Context, name string) (*entities.CloudProviderSecret, error)
 	InfraListDomainEntries(ctx context.Context, search *model.SearchDomainEntry, pagination *repos.CursorPagination) (*model.DomainEntryPaginatedRecords, error)
 	InfraGetDomainEntry(ctx context.Context, domainName string) (*entities.DomainEntry, error)
-	InfraCheckAwsAccess(ctx context.Context, accountID string) (*model.CheckAwsAccessOutput, error)
+	InfraCheckAwsAccess(ctx context.Context, cloudproviderName string) (*model.CheckAwsAccessOutput, error)
 	InfraListVPNDevices(ctx context.Context, clusterName *string, search *model.SearchVPNDevices, pq *repos.CursorPagination) (*model.VPNDevicePaginatedRecords, error)
 	InfraGetVPNDevice(ctx context.Context, clusterName string, name string) (*entities.VPNDevice, error)
 	InfraGetVPNDeviceConfig(ctx context.Context, clusterName string, name string) (string, error)
@@ -684,11 +694,10 @@ type BYOCClusterInResolver interface {
 	Spec(ctx context.Context, obj *entities.BYOCCluster, data *model.GithubComKloudliteOperatorApisClustersV1BYOCSpecIn) error
 }
 type CloudProviderSecretInResolver interface {
-	Data(ctx context.Context, obj *entities.CloudProviderSecret, data map[string]interface{}) error
+	Aws(ctx context.Context, obj *entities.CloudProviderSecret, data *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn) error
+	CloudProviderName(ctx context.Context, obj *entities.CloudProviderSecret, data model.GithubComKloudliteOperatorApisCommonTypesCloudProvider) error
 
 	Metadata(ctx context.Context, obj *entities.CloudProviderSecret, data *v1.ObjectMeta) error
-	StringData(ctx context.Context, obj *entities.CloudProviderSecret, data map[string]interface{}) error
-	Type(ctx context.Context, obj *entities.CloudProviderSecret, data *model.K8sIoAPICoreV1SecretType) error
 }
 type ClusterInResolver interface {
 	Metadata(ctx context.Context, obj *entities.Cluster, data *v1.ObjectMeta) error
@@ -911,19 +920,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CheckNameAvailabilityOutput.SuggestedNames(childComplexity), true
 
-	case "CloudProviderSecret.apiVersion":
-		if e.complexity.CloudProviderSecret.APIVersion == nil {
-			break
-		}
-
-		return e.complexity.CloudProviderSecret.APIVersion(childComplexity), true
-
 	case "CloudProviderSecret.accountName":
 		if e.complexity.CloudProviderSecret.AccountName == nil {
 			break
 		}
 
 		return e.complexity.CloudProviderSecret.AccountName(childComplexity), true
+
+	case "CloudProviderSecret.aws":
+		if e.complexity.CloudProviderSecret.Aws == nil {
+			break
+		}
+
+		return e.complexity.CloudProviderSecret.Aws(childComplexity), true
 
 	case "CloudProviderSecret.cloudProviderName":
 		if e.complexity.CloudProviderSecret.CloudProviderName == nil {
@@ -946,13 +955,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CloudProviderSecret.CreationTime(childComplexity), true
 
-	case "CloudProviderSecret.data":
-		if e.complexity.CloudProviderSecret.Data == nil {
-			break
-		}
-
-		return e.complexity.CloudProviderSecret.Data(childComplexity), true
-
 	case "CloudProviderSecret.displayName":
 		if e.complexity.CloudProviderSecret.DisplayName == nil {
 			break
@@ -966,20 +968,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CloudProviderSecret.ID(childComplexity), true
-
-	case "CloudProviderSecret.immutable":
-		if e.complexity.CloudProviderSecret.Immutable == nil {
-			break
-		}
-
-		return e.complexity.CloudProviderSecret.Immutable(childComplexity), true
-
-	case "CloudProviderSecret.kind":
-		if e.complexity.CloudProviderSecret.Kind == nil {
-			break
-		}
-
-		return e.complexity.CloudProviderSecret.Kind(childComplexity), true
 
 	case "CloudProviderSecret.lastUpdatedBy":
 		if e.complexity.CloudProviderSecret.LastUpdatedBy == nil {
@@ -1008,20 +996,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CloudProviderSecret.RecordVersion(childComplexity), true
-
-	case "CloudProviderSecret.stringData":
-		if e.complexity.CloudProviderSecret.StringData == nil {
-			break
-		}
-
-		return e.complexity.CloudProviderSecret.StringData(childComplexity), true
-
-	case "CloudProviderSecret.type":
-		if e.complexity.CloudProviderSecret.Type == nil {
-			break
-		}
-
-		return e.complexity.CloudProviderSecret.Type(childComplexity), true
 
 	case "CloudProviderSecret.updateTime":
 		if e.complexity.CloudProviderSecret.UpdateTime == nil {
@@ -1359,20 +1333,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DomainEntryPaginatedRecords.TotalCount(childComplexity), true
 
-	case "Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.awsAccountId":
-		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.AwsAccountID == nil {
-			break
-		}
-
-		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.AwsAccountID(childComplexity), true
-
-	case "Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.awsAssumeRoleParamExternalIdRef":
-		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.AwsAssumeRoleParamExternalIDRef == nil {
-			break
-		}
-
-		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.AwsAssumeRoleParamExternalIDRef(childComplexity), true
-
 	case "Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.k3sMasters":
 		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig.K3sMasters == nil {
 			break
@@ -1695,6 +1655,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__BYOCSpec.StorageClasses(childComplexity), true
 
+	case "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.keyAWSAccountId":
+		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAWSAccountID == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAWSAccountID(childComplexity), true
+
+	case "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.keyAWSAssumeRoleExternalID":
+		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAWSAssumeRoleExternalID == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAWSAssumeRoleExternalID(childComplexity), true
+
+	case "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.keyAWSAssumeRoleRoleARN":
+		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAWSAssumeRoleRoleArn == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAWSAssumeRoleRoleArn(childComplexity), true
+
+	case "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.keyAccessKey":
+		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAccessKey == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeyAccessKey(childComplexity), true
+
+	case "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.keySecretKey":
+		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeySecretKey == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys.KeySecretKey(childComplexity), true
+
 	case "Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput.keyK3sAgentJoinToken":
 		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput.KeyK3sAgentJoinToken == nil {
 			break
@@ -1785,6 +1780,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec.ClusterTokenRef(childComplexity), true
+
+	case "Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec.credentialKeys":
+		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec.CredentialKeys == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec.CredentialKeys(childComplexity), true
 
 	case "Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec.credentialsRef":
 		if e.complexity.Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec.CredentialsRef == nil {
@@ -2079,6 +2081,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Github__com___kloudlite___operator___pkg___raw____json__RawJson.RawMessage(childComplexity), true
+
+	case "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.accessKey":
+		if e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AccessKey == nil {
+			break
+		}
+
+		return e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AccessKey(childComplexity), true
+
+	case "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.awsAccountId":
+		if e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AwsAccountID == nil {
+			break
+		}
+
+		return e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AwsAccountID(childComplexity), true
+
+	case "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.awsAssumeRoleExternalId":
+		if e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AwsAssumeRoleExternalID == nil {
+			break
+		}
+
+		return e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AwsAssumeRoleExternalID(childComplexity), true
+
+	case "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.awsAssumeRoleRoleARN":
+		if e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AwsAssumeRoleRoleArn == nil {
+			break
+		}
+
+		return e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.AwsAssumeRoleRoleArn(childComplexity), true
+
+	case "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.secretKey":
+		if e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.SecretKey == nil {
+			break
+		}
+
+		return e.complexity.Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials.SecretKey(childComplexity), true
 
 	case "Kloudlite__io___apps___infra___internal___entities__HelmStatusVal.isReady":
 		if e.complexity.Kloudlite__io___apps___infra___internal___entities__HelmStatusVal.IsReady == nil {
@@ -2761,7 +2798,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.InfraCheckAwsAccess(childComplexity, args["accountId"].(string)), true
+		return e.complexity.Query.InfraCheckAwsAccess(childComplexity, args["cloudproviderName"].(string)), true
 
 	case "Query.infra_checkNameAvailability":
 		if e.complexity.Query.InfraCheckNameAvailability == nil {
@@ -3128,6 +3165,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputGithub__com___kloudlite___operator___apis___common____types__SecretRefIn,
 		ec.unmarshalInputGithub__com___kloudlite___operator___apis___wireguard___v1__DeviceSpecIn,
 		ec.unmarshalInputGithub__com___kloudlite___operator___apis___wireguard___v1__PortIn,
+		ec.unmarshalInputKloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn,
 		ec.unmarshalInputMatchFilterIn,
 		ec.unmarshalInputMetadataIn,
 		ec.unmarshalInputNodeIn,
@@ -3246,12 +3284,12 @@ input SearchVPNDevices {
 
 type CheckAwsAccessOutput {
     result: Boolean!
-    installationUrl: String
+    installationUrl: Any
 }
 
 type Query {
     # unique name suggestions
-    infra_checkNameAvailability(resType: ResType!, clusterName: String, name: String!): CheckNameAvailabilityOutput! @isLoggedIn @hasAccount
+    infra_checkNameAvailability(resType: ResType!, clusterName: String, name: String!): CheckNameAvailabilityOutput! @isLoggedIn 
 
     # clusters
     infra_listClusters(search: SearchCluster, pagination: CursorPaginationIn): ClusterPaginatedRecords @isLoggedInAndVerified @hasAccount
@@ -3270,7 +3308,7 @@ type Query {
     infra_listDomainEntries(search: SearchDomainEntry, pagination: CursorPaginationIn): DomainEntryPaginatedRecords @isLoggedInAndVerified @hasAccount
     infra_getDomainEntry(domainName: String!): DomainEntry @isLoggedInAndVerified @hasAccount
 
-    infra_checkAwsAccess(accountId: String!): CheckAwsAccessOutput! @isLoggedInAndVerified @hasAccount
+    infra_checkAwsAccess(cloudproviderName: String!): CheckAwsAccessOutput! @isLoggedInAndVerified @hasAccount
 
     infra_listVPNDevices(clusterName: String, search: SearchVPNDevices, pq: CursorPaginationIn): VPNDevicePaginatedRecords @isLoggedInAndVerified @hasAccount
     infra_getVPNDevice(clusterName: String!, name: String!): VPNDevice @isLoggedInAndVerified @hasAccount
@@ -3353,21 +3391,16 @@ input BYOCClusterIn {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/cloudprovidersecret.graphqls", Input: `type CloudProviderSecret @shareable {
   accountName: String!
-  apiVersion: String!
-  cloudProviderName: Kloudlite__io___apps___infra___internal___entities__CloudProviderName!
+  aws: Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials
+  cloudProviderName: Github__com___kloudlite___operator___apis___common____types__CloudProvider!
   createdBy: Kloudlite__io___common__CreatedOrUpdatedBy!
   creationTime: Date!
-  data: Map
   displayName: String!
   id: String!
-  immutable: Boolean
-  kind: String!
   lastUpdatedBy: Kloudlite__io___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
-  metadata: Metadata @goField(name: "objectMeta")
+  metadata: Metadata! @goField(name: "objectMeta")
   recordVersion: Int!
-  stringData: Map
-  type: K8s__io___api___core___v1__SecretType
   updateTime: Date!
 }
 
@@ -3383,13 +3416,10 @@ type CloudProviderSecretPaginatedRecords @shareable {
 }
 
 input CloudProviderSecretIn {
-  cloudProviderName: Kloudlite__io___apps___infra___internal___entities__CloudProviderName!
-  data: Map
+  aws: Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn
+  cloudProviderName: Github__com___kloudlite___operator___apis___common____types__CloudProvider!
   displayName: String!
-  immutable: Boolean
-  metadata: MetadataIn
-  stringData: Map
-  type: K8s__io___api___core___v1__SecretType
+  metadata: MetadataIn!
 }
 
 `, BuiltIn: false},
@@ -3430,8 +3460,6 @@ input ClusterIn {
 
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/common-types.graphqls", Input: `type Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig @shareable {
-  awsAccountId: String!
-  awsAssumeRoleParamExternalIdRef: Github__com___kloudlite___operator___apis___common____types__SecretKeyRef
   k3sMasters: Github__com___kloudlite___operator___apis___clusters___v1__AWSK3sMastersConfig
   nodePools: Map
   region: String!
@@ -3501,6 +3529,14 @@ type Github__com___kloudlite___operator___apis___clusters___v1__BYOCSpec @sharea
   storageClasses: [String!]
 }
 
+type Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys @shareable {
+  keyAccessKey: String!
+  keyAWSAccountId: String!
+  keyAWSAssumeRoleExternalID: String!
+  keyAWSAssumeRoleRoleARN: String!
+  keySecretKey: String!
+}
+
 type Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput @shareable {
   keyK3sAgentJoinToken: String!
   keyK3sServerJoinToken: String!
@@ -3518,6 +3554,7 @@ type Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec @sha
   cloudProvider: Github__com___kloudlite___operator___apis___common____types__CloudProvider!
   clusterInternalDnsHost: String
   clusterTokenRef: Github__com___kloudlite___operator___apis___common____types__SecretKeyRef
+  credentialKeys: Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys
   credentialsRef: Github__com___kloudlite___operator___apis___common____types__SecretRef!
   kloudliteRelease: String!
   messageQueueTopicName: String!
@@ -3601,6 +3638,14 @@ type Github__com___kloudlite___operator___pkg___raw____json__RawJson @shareable 
   RawMessage: Any
 }
 
+type Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials @shareable {
+  accessKey: String
+  awsAccountId: String
+  awsAssumeRoleExternalId: String
+  awsAssumeRoleRoleARN: String
+  secretKey: String
+}
+
 type Kloudlite__io___apps___infra___internal___entities__HelmStatusVal @shareable {
   isReady: Boolean
   message: String!
@@ -3639,7 +3684,6 @@ type PageInfo @shareable {
 }
 
 input Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfigIn {
-  awsAccountId: String!
   k3sMasters: Github__com___kloudlite___operator___apis___clusters___v1__AWSK3sMastersConfigIn
   region: String!
 }
@@ -3746,6 +3790,12 @@ input Github__com___kloudlite___operator___apis___wireguard___v1__PortIn {
   targetPort: Int
 }
 
+input Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn {
+  accessKey: String
+  awsAccountId: String
+  secretKey: String
+}
+
 input MetadataIn {
   annotations: Map
   labels: Map
@@ -3763,27 +3813,6 @@ enum Github__com___kloudlite___operator___apis___common____types__CloudProvider 
   azure
   do
   gcp
-}
-
-enum K8s__io___api___core___v1__SecretType {
-  bootstrap__kubernetes__io___token
-  kubernetes__io___basic____auth
-  kubernetes__io___dockercfg
-  kubernetes__io___dockerconfigjson
-  kubernetes__io___service____account____token
-  kubernetes__io___ssh____auth
-  kubernetes__io___tls
-  Opaque
-}
-
-enum Kloudlite__io___apps___infra___internal___entities__CloudProviderName {
-  aws
-  azure
-  do
-  gcp
-  oci
-  openstack
-  vmware
 }
 
 enum Kloudlite__io___pkg___types__SyncStatusAction {
@@ -4370,14 +4399,14 @@ func (ec *executionContext) field_Query_infra_checkAwsAccess_args(ctx context.Co
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
-	if tmp, ok := rawArgs["accountId"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("accountId"))
+	if tmp, ok := rawArgs["cloudproviderName"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cloudproviderName"))
 		arg0, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["accountId"] = arg0
+	args["cloudproviderName"] = arg0
 	return args, nil
 }
 
@@ -5948,9 +5977,9 @@ func (ec *executionContext) _CheckAwsAccessOutput_installationUrl(ctx context.Co
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(interface{})
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOAny2interface(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CheckAwsAccessOutput_installationUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5960,7 +5989,7 @@ func (ec *executionContext) fieldContext_CheckAwsAccessOutput_installationUrl(ct
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Any does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6098,8 +6127,8 @@ func (ec *executionContext) fieldContext_CloudProviderSecret_accountName(ctx con
 	return fc, nil
 }
 
-func (ec *executionContext) _CloudProviderSecret_apiVersion(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CloudProviderSecret_apiVersion(ctx, field)
+func (ec *executionContext) _CloudProviderSecret_aws(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CloudProviderSecret_aws(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -6112,31 +6141,40 @@ func (ec *executionContext) _CloudProviderSecret_apiVersion(ctx context.Context,
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.APIVersion, nil
+		return ec.resolvers.CloudProviderSecret().Aws(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOKloudlite__io___apps___infra___internal___entities__AWSSecretCredentials2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐKloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_CloudProviderSecret_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_CloudProviderSecret_aws(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "CloudProviderSecret",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "accessKey":
+				return ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_accessKey(ctx, field)
+			case "awsAccountId":
+				return ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAccountId(ctx, field)
+			case "awsAssumeRoleExternalId":
+				return ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleExternalId(ctx, field)
+			case "awsAssumeRoleRoleARN":
+				return ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleRoleARN(ctx, field)
+			case "secretKey":
+				return ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_secretKey(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials", field.Name)
 		},
 	}
 	return fc, nil
@@ -6156,7 +6194,7 @@ func (ec *executionContext) _CloudProviderSecret_cloudProviderName(ctx context.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.CloudProviderName, nil
+		return ec.resolvers.CloudProviderSecret().CloudProviderName(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6168,19 +6206,19 @@ func (ec *executionContext) _CloudProviderSecret_cloudProviderName(ctx context.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(entities.CloudProviderName)
+	res := resTmp.(model.GithubComKloudliteOperatorApisCommonTypesCloudProvider)
 	fc.Result = res
-	return ec.marshalNKloudlite__io___apps___infra___internal___entities__CloudProviderName2kloudliteᚗioᚋappsᚋinfraᚋinternalᚋentitiesᚐCloudProviderName(ctx, field.Selections, res)
+	return ec.marshalNGithub__com___kloudlite___operator___apis___common____types__CloudProvider2kloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐGithubComKloudliteOperatorApisCommonTypesCloudProvider(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CloudProviderSecret_cloudProviderName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "CloudProviderSecret",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Kloudlite__io___apps___infra___internal___entities__CloudProviderName does not have child fields")
+			return nil, errors.New("field of type Github__com___kloudlite___operator___apis___common____types__CloudProvider does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6282,47 +6320,6 @@ func (ec *executionContext) fieldContext_CloudProviderSecret_creationTime(ctx co
 	return fc, nil
 }
 
-func (ec *executionContext) _CloudProviderSecret_data(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CloudProviderSecret_data(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.CloudProviderSecret().Data(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(map[string]interface{})
-	fc.Result = res
-	return ec.marshalOMap2map(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CloudProviderSecret_data(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CloudProviderSecret",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Map does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _CloudProviderSecret_displayName(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CloudProviderSecret_displayName(ctx, field)
 	if err != nil {
@@ -6404,91 +6401,6 @@ func (ec *executionContext) fieldContext_CloudProviderSecret_id(ctx context.Cont
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CloudProviderSecret_immutable(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CloudProviderSecret_immutable(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Immutable, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CloudProviderSecret_immutable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CloudProviderSecret",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CloudProviderSecret_kind(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CloudProviderSecret_kind(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Kind, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CloudProviderSecret_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CloudProviderSecret",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -6610,11 +6522,14 @@ func (ec *executionContext) _CloudProviderSecret_metadata(ctx context.Context, f
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(v1.ObjectMeta)
 	fc.Result = res
-	return ec.marshalOMetadata2k8sᚗioᚋapimachineryᚋpkgᚋapisᚋmetaᚋv1ᚐObjectMeta(ctx, field.Selections, res)
+	return ec.marshalNMetadata2k8sᚗioᚋapimachineryᚋpkgᚋapisᚋmetaᚋv1ᚐObjectMeta(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CloudProviderSecret_metadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -6685,88 +6600,6 @@ func (ec *executionContext) fieldContext_CloudProviderSecret_recordVersion(ctx c
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CloudProviderSecret_stringData(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CloudProviderSecret_stringData(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.CloudProviderSecret().StringData(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(map[string]interface{})
-	fc.Result = res
-	return ec.marshalOMap2map(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CloudProviderSecret_stringData(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CloudProviderSecret",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Map does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CloudProviderSecret_type(ctx context.Context, field graphql.CollectedField, obj *entities.CloudProviderSecret) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CloudProviderSecret_type(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.CloudProviderSecret().Type(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.K8sIoAPICoreV1SecretType)
-	fc.Result = res
-	return ec.marshalOK8s__io___api___core___v1__SecretType2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐK8sIoAPICoreV1SecretType(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CloudProviderSecret_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CloudProviderSecret",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type K8s__io___api___core___v1__SecretType does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6901,24 +6734,18 @@ func (ec *executionContext) fieldContext_CloudProviderSecretEdge_node(ctx contex
 			switch field.Name {
 			case "accountName":
 				return ec.fieldContext_CloudProviderSecret_accountName(ctx, field)
-			case "apiVersion":
-				return ec.fieldContext_CloudProviderSecret_apiVersion(ctx, field)
+			case "aws":
+				return ec.fieldContext_CloudProviderSecret_aws(ctx, field)
 			case "cloudProviderName":
 				return ec.fieldContext_CloudProviderSecret_cloudProviderName(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_CloudProviderSecret_createdBy(ctx, field)
 			case "creationTime":
 				return ec.fieldContext_CloudProviderSecret_creationTime(ctx, field)
-			case "data":
-				return ec.fieldContext_CloudProviderSecret_data(ctx, field)
 			case "displayName":
 				return ec.fieldContext_CloudProviderSecret_displayName(ctx, field)
 			case "id":
 				return ec.fieldContext_CloudProviderSecret_id(ctx, field)
-			case "immutable":
-				return ec.fieldContext_CloudProviderSecret_immutable(ctx, field)
-			case "kind":
-				return ec.fieldContext_CloudProviderSecret_kind(ctx, field)
 			case "lastUpdatedBy":
 				return ec.fieldContext_CloudProviderSecret_lastUpdatedBy(ctx, field)
 			case "markedForDeletion":
@@ -6927,10 +6754,6 @@ func (ec *executionContext) fieldContext_CloudProviderSecretEdge_node(ctx contex
 				return ec.fieldContext_CloudProviderSecret_metadata(ctx, field)
 			case "recordVersion":
 				return ec.fieldContext_CloudProviderSecret_recordVersion(ctx, field)
-			case "stringData":
-				return ec.fieldContext_CloudProviderSecret_stringData(ctx, field)
-			case "type":
-				return ec.fieldContext_CloudProviderSecret_type(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_CloudProviderSecret_updateTime(ctx, field)
 			}
@@ -7658,6 +7481,8 @@ func (ec *executionContext) fieldContext_Cluster_spec(ctx context.Context, field
 				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_clusterInternalDnsHost(ctx, field)
 			case "clusterTokenRef":
 				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_clusterTokenRef(ctx, field)
+			case "credentialKeys":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_credentialKeys(ctx, field)
 			case "credentialsRef":
 				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_credentialsRef(ctx, field)
 			case "kloudliteRelease":
@@ -9100,99 +8925,6 @@ func (ec *executionContext) fieldContext_DomainEntryPaginatedRecords_totalCount(
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAccountId(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1AWSClusterConfig) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAccountId(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AwsAccountID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAccountId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAssumeRoleParamExternalIdRef(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1AWSClusterConfig) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAssumeRoleParamExternalIdRef(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AwsAssumeRoleParamExternalIDRef, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.GithubComKloudliteOperatorApisCommonTypesSecretKeyRef)
-	fc.Result = res
-	return ec.marshalOGithub__com___kloudlite___operator___apis___common____types__SecretKeyRef2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐGithubComKloudliteOperatorApisCommonTypesSecretKeyRef(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAssumeRoleParamExternalIdRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "key":
-				return ec.fieldContext_Github__com___kloudlite___operator___apis___common____types__SecretKeyRef_key(ctx, field)
-			case "name":
-				return ec.fieldContext_Github__com___kloudlite___operator___apis___common____types__SecretKeyRef_name(ctx, field)
-			case "namespace":
-				return ec.fieldContext_Github__com___kloudlite___operator___apis___common____types__SecretKeyRef_namespace(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Github__com___kloudlite___operator___apis___common____types__SecretKeyRef", field.Name)
 		},
 	}
 	return fc, nil
@@ -11246,6 +10978,226 @@ func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___ap
 	return fc, nil
 }
 
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAccessKey(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAccessKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KeyAccessKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAccessKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAccountId(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAccountId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KeyAWSAccountID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAccountId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleExternalID(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleExternalID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KeyAWSAssumeRoleExternalID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleExternalID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleRoleARN(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleRoleARN(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KeyAWSAssumeRoleRoleArn, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleRoleARN(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keySecretKey(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keySecretKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KeySecretKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keySecretKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput_keyK3sAgentJoinToken(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1ClusterOutput) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput_keyK3sAgentJoinToken(ctx, field)
 	if err != nil {
@@ -11590,10 +11542,6 @@ func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___ap
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "awsAccountId":
-				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAccountId(ctx, field)
-			case "awsAssumeRoleParamExternalIdRef":
-				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAssumeRoleParamExternalIdRef(ctx, field)
 			case "k3sMasters":
 				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_k3sMasters(ctx, field)
 			case "nodePools":
@@ -11823,6 +11771,59 @@ func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___ap
 				return ec.fieldContext_Github__com___kloudlite___operator___apis___common____types__SecretKeyRef_namespace(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Github__com___kloudlite___operator___apis___common____types__SecretKeyRef", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_credentialKeys(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisClustersV1ClusterSpec) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_credentialKeys(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CredentialKeys, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys)
+	fc.Result = res
+	return ec.marshalOGithub__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐGithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_credentialKeys(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "keyAccessKey":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAccessKey(ctx, field)
+			case "keyAWSAccountId":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAccountId(ctx, field)
+			case "keyAWSAssumeRoleExternalID":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleExternalID(ctx, field)
+			case "keyAWSAssumeRoleRoleARN":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleRoleARN(ctx, field)
+			case "keySecretKey":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keySecretKey(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys", field.Name)
 		},
 	}
 	return fc, nil
@@ -13666,6 +13667,211 @@ func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___pk
 	return fc, nil
 }
 
+func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_accessKey(ctx context.Context, field graphql.CollectedField, obj *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_accessKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AccessKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_accessKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAccountId(ctx context.Context, field graphql.CollectedField, obj *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAccountId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AwsAccountID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAccountId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleExternalId(ctx context.Context, field graphql.CollectedField, obj *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleExternalId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AwsAssumeRoleExternalID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleExternalId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleRoleARN(ctx context.Context, field graphql.CollectedField, obj *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleRoleARN(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AwsAssumeRoleRoleArn, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleRoleARN(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_secretKey(ctx context.Context, field graphql.CollectedField, obj *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_secretKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SecretKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_secretKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__HelmStatusVal_isReady(ctx context.Context, field graphql.CollectedField, obj *model.KloudliteIoAppsInfraInternalEntitiesHelmStatusVal) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Kloudlite__io___apps___infra___internal___entities__HelmStatusVal_isReady(ctx, field)
 	if err != nil {
@@ -15279,24 +15485,18 @@ func (ec *executionContext) fieldContext_Mutation_infra_createProviderSecret(ctx
 			switch field.Name {
 			case "accountName":
 				return ec.fieldContext_CloudProviderSecret_accountName(ctx, field)
-			case "apiVersion":
-				return ec.fieldContext_CloudProviderSecret_apiVersion(ctx, field)
+			case "aws":
+				return ec.fieldContext_CloudProviderSecret_aws(ctx, field)
 			case "cloudProviderName":
 				return ec.fieldContext_CloudProviderSecret_cloudProviderName(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_CloudProviderSecret_createdBy(ctx, field)
 			case "creationTime":
 				return ec.fieldContext_CloudProviderSecret_creationTime(ctx, field)
-			case "data":
-				return ec.fieldContext_CloudProviderSecret_data(ctx, field)
 			case "displayName":
 				return ec.fieldContext_CloudProviderSecret_displayName(ctx, field)
 			case "id":
 				return ec.fieldContext_CloudProviderSecret_id(ctx, field)
-			case "immutable":
-				return ec.fieldContext_CloudProviderSecret_immutable(ctx, field)
-			case "kind":
-				return ec.fieldContext_CloudProviderSecret_kind(ctx, field)
 			case "lastUpdatedBy":
 				return ec.fieldContext_CloudProviderSecret_lastUpdatedBy(ctx, field)
 			case "markedForDeletion":
@@ -15305,10 +15505,6 @@ func (ec *executionContext) fieldContext_Mutation_infra_createProviderSecret(ctx
 				return ec.fieldContext_CloudProviderSecret_metadata(ctx, field)
 			case "recordVersion":
 				return ec.fieldContext_CloudProviderSecret_recordVersion(ctx, field)
-			case "stringData":
-				return ec.fieldContext_CloudProviderSecret_stringData(ctx, field)
-			case "type":
-				return ec.fieldContext_CloudProviderSecret_type(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_CloudProviderSecret_updateTime(ctx, field)
 			}
@@ -15393,24 +15589,18 @@ func (ec *executionContext) fieldContext_Mutation_infra_updateProviderSecret(ctx
 			switch field.Name {
 			case "accountName":
 				return ec.fieldContext_CloudProviderSecret_accountName(ctx, field)
-			case "apiVersion":
-				return ec.fieldContext_CloudProviderSecret_apiVersion(ctx, field)
+			case "aws":
+				return ec.fieldContext_CloudProviderSecret_aws(ctx, field)
 			case "cloudProviderName":
 				return ec.fieldContext_CloudProviderSecret_cloudProviderName(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_CloudProviderSecret_createdBy(ctx, field)
 			case "creationTime":
 				return ec.fieldContext_CloudProviderSecret_creationTime(ctx, field)
-			case "data":
-				return ec.fieldContext_CloudProviderSecret_data(ctx, field)
 			case "displayName":
 				return ec.fieldContext_CloudProviderSecret_displayName(ctx, field)
 			case "id":
 				return ec.fieldContext_CloudProviderSecret_id(ctx, field)
-			case "immutable":
-				return ec.fieldContext_CloudProviderSecret_immutable(ctx, field)
-			case "kind":
-				return ec.fieldContext_CloudProviderSecret_kind(ctx, field)
 			case "lastUpdatedBy":
 				return ec.fieldContext_CloudProviderSecret_lastUpdatedBy(ctx, field)
 			case "markedForDeletion":
@@ -15419,10 +15609,6 @@ func (ec *executionContext) fieldContext_Mutation_infra_updateProviderSecret(ctx
 				return ec.fieldContext_CloudProviderSecret_metadata(ctx, field)
 			case "recordVersion":
 				return ec.fieldContext_CloudProviderSecret_recordVersion(ctx, field)
-			case "stringData":
-				return ec.fieldContext_CloudProviderSecret_stringData(ctx, field)
-			case "type":
-				return ec.fieldContext_CloudProviderSecret_type(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_CloudProviderSecret_updateTime(ctx, field)
 			}
@@ -18522,14 +18708,8 @@ func (ec *executionContext) _Query_infra_checkNameAvailability(ctx context.Conte
 			}
 			return ec.directives.IsLoggedIn(ctx, nil, directive0)
 		}
-		directive2 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.HasAccount == nil {
-				return nil, errors.New("directive hasAccount is not implemented")
-			}
-			return ec.directives.HasAccount(ctx, nil, directive1)
-		}
 
-		tmp, err := directive2(rctx)
+		tmp, err := directive1(rctx)
 		if err != nil {
 			return nil, graphql.ErrorOnPath(ctx, err)
 		}
@@ -19332,24 +19512,18 @@ func (ec *executionContext) fieldContext_Query_infra_getProviderSecret(ctx conte
 			switch field.Name {
 			case "accountName":
 				return ec.fieldContext_CloudProviderSecret_accountName(ctx, field)
-			case "apiVersion":
-				return ec.fieldContext_CloudProviderSecret_apiVersion(ctx, field)
+			case "aws":
+				return ec.fieldContext_CloudProviderSecret_aws(ctx, field)
 			case "cloudProviderName":
 				return ec.fieldContext_CloudProviderSecret_cloudProviderName(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_CloudProviderSecret_createdBy(ctx, field)
 			case "creationTime":
 				return ec.fieldContext_CloudProviderSecret_creationTime(ctx, field)
-			case "data":
-				return ec.fieldContext_CloudProviderSecret_data(ctx, field)
 			case "displayName":
 				return ec.fieldContext_CloudProviderSecret_displayName(ctx, field)
 			case "id":
 				return ec.fieldContext_CloudProviderSecret_id(ctx, field)
-			case "immutable":
-				return ec.fieldContext_CloudProviderSecret_immutable(ctx, field)
-			case "kind":
-				return ec.fieldContext_CloudProviderSecret_kind(ctx, field)
 			case "lastUpdatedBy":
 				return ec.fieldContext_CloudProviderSecret_lastUpdatedBy(ctx, field)
 			case "markedForDeletion":
@@ -19358,10 +19532,6 @@ func (ec *executionContext) fieldContext_Query_infra_getProviderSecret(ctx conte
 				return ec.fieldContext_CloudProviderSecret_metadata(ctx, field)
 			case "recordVersion":
 				return ec.fieldContext_CloudProviderSecret_recordVersion(ctx, field)
-			case "stringData":
-				return ec.fieldContext_CloudProviderSecret_stringData(ctx, field)
-			case "type":
-				return ec.fieldContext_CloudProviderSecret_type(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_CloudProviderSecret_updateTime(ctx, field)
 			}
@@ -19585,7 +19755,7 @@ func (ec *executionContext) _Query_infra_checkAwsAccess(ctx context.Context, fie
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().InfraCheckAwsAccess(rctx, fc.Args["accountId"].(string))
+			return ec.resolvers.Query().InfraCheckAwsAccess(rctx, fc.Args["cloudproviderName"].(string))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.IsLoggedInAndVerified == nil {
@@ -23067,30 +23237,33 @@ func (ec *executionContext) unmarshalInputCloudProviderSecretIn(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"cloudProviderName", "data", "displayName", "immutable", "metadata", "stringData", "type"}
+	fieldsInOrder := [...]string{"aws", "cloudProviderName", "displayName", "metadata"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "aws":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("aws"))
+			data, err := ec.unmarshalOKloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐKloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			if err = ec.resolvers.CloudProviderSecretIn().Aws(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "cloudProviderName":
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cloudProviderName"))
-			it.CloudProviderName, err = ec.unmarshalNKloudlite__io___apps___infra___internal___entities__CloudProviderName2kloudliteᚗioᚋappsᚋinfraᚋinternalᚋentitiesᚐCloudProviderName(ctx, v)
+			data, err := ec.unmarshalNGithub__com___kloudlite___operator___apis___common____types__CloudProvider2kloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐGithubComKloudliteOperatorApisCommonTypesCloudProvider(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "data":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("data"))
-			data, err := ec.unmarshalOMap2map(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			if err = ec.resolvers.CloudProviderSecretIn().Data(ctx, &it, data); err != nil {
+			if err = ec.resolvers.CloudProviderSecretIn().CloudProviderName(ctx, &it, data); err != nil {
 				return it, err
 			}
 		case "displayName":
@@ -23101,45 +23274,15 @@ func (ec *executionContext) unmarshalInputCloudProviderSecretIn(ctx context.Cont
 			if err != nil {
 				return it, err
 			}
-		case "immutable":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("immutable"))
-			it.Immutable, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "metadata":
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metadata"))
-			data, err := ec.unmarshalOMetadataIn2ᚖk8sᚗioᚋapimachineryᚋpkgᚋapisᚋmetaᚋv1ᚐObjectMeta(ctx, v)
+			data, err := ec.unmarshalNMetadataIn2ᚖk8sᚗioᚋapimachineryᚋpkgᚋapisᚋmetaᚋv1ᚐObjectMeta(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			if err = ec.resolvers.CloudProviderSecretIn().Metadata(ctx, &it, data); err != nil {
-				return it, err
-			}
-		case "stringData":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("stringData"))
-			data, err := ec.unmarshalOMap2map(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			if err = ec.resolvers.CloudProviderSecretIn().StringData(ctx, &it, data); err != nil {
-				return it, err
-			}
-		case "type":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
-			data, err := ec.unmarshalOK8s__io___api___core___v1__SecretType2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐK8sIoAPICoreV1SecretType(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			if err = ec.resolvers.CloudProviderSecretIn().Type(ctx, &it, data); err != nil {
 				return it, err
 			}
 		}
@@ -23324,21 +23467,13 @@ func (ec *executionContext) unmarshalInputGithub__com___kloudlite___operator___a
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"awsAccountId", "k3sMasters", "region"}
+	fieldsInOrder := [...]string{"k3sMasters", "region"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "awsAccountId":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("awsAccountId"))
-			it.AwsAccountID, err = ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "k3sMasters":
 			var err error
 
@@ -24108,6 +24243,50 @@ func (ec *executionContext) unmarshalInputGithub__com___kloudlite___operator___a
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("targetPort"))
 			it.TargetPort, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputKloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn(ctx context.Context, obj interface{}) (model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn, error) {
+	var it model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"accessKey", "awsAccountId", "secretKey"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "accessKey":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("accessKey"))
+			it.AccessKey, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "awsAccountId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("awsAccountId"))
+			it.AwsAccountID, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "secretKey":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("secretKey"))
+			it.SecretKey, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -24931,20 +25110,43 @@ func (ec *executionContext) _CloudProviderSecret(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "apiVersion":
+		case "aws":
+			field := field
 
-			out.Values[i] = ec._CloudProviderSecret_apiVersion(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._CloudProviderSecret_aws(ctx, field, obj)
+				return res
 			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "cloudProviderName":
+			field := field
 
-			out.Values[i] = ec._CloudProviderSecret_cloudProviderName(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._CloudProviderSecret_cloudProviderName(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
 			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "createdBy":
 
 			out.Values[i] = ec._CloudProviderSecret_createdBy(ctx, field, obj)
@@ -24965,23 +25167,6 @@ func (ec *executionContext) _CloudProviderSecret(ctx context.Context, sel ast.Se
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
-				return res
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
-		case "data":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._CloudProviderSecret_data(ctx, field, obj)
 				return res
 			}
 
@@ -25016,17 +25201,6 @@ func (ec *executionContext) _CloudProviderSecret(ctx context.Context, sel ast.Se
 				return innerFunc(ctx)
 
 			})
-		case "immutable":
-
-			out.Values[i] = ec._CloudProviderSecret_immutable(ctx, field, obj)
-
-		case "kind":
-
-			out.Values[i] = ec._CloudProviderSecret_kind(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._CloudProviderSecret_lastUpdatedBy(ctx, field, obj)
@@ -25042,6 +25216,9 @@ func (ec *executionContext) _CloudProviderSecret(ctx context.Context, sel ast.Se
 
 			out.Values[i] = ec._CloudProviderSecret_metadata(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "recordVersion":
 
 			out.Values[i] = ec._CloudProviderSecret_recordVersion(ctx, field, obj)
@@ -25049,40 +25226,6 @@ func (ec *executionContext) _CloudProviderSecret(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "stringData":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._CloudProviderSecret_stringData(ctx, field, obj)
-				return res
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
-		case "type":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._CloudProviderSecret_type(ctx, field, obj)
-				return res
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "updateTime":
 			field := field
 
@@ -25706,17 +25849,6 @@ func (ec *executionContext) _Github__com___kloudlite___operator___apis___cluster
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig")
-		case "awsAccountId":
-
-			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAccountId(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "awsAssumeRoleParamExternalIdRef":
-
-			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_awsAssumeRoleParamExternalIdRef(ctx, field, obj)
-
 		case "k3sMasters":
 
 			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig_k3sMasters(ctx, field, obj)
@@ -26137,6 +26269,62 @@ func (ec *executionContext) _Github__com___kloudlite___operator___apis___cluster
 	return out
 }
 
+var github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeysImplementors = []string{"Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys"}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys(ctx context.Context, sel ast.SelectionSet, obj *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeysImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys")
+		case "keyAccessKey":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAccessKey(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "keyAWSAccountId":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAccountId(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "keyAWSAssumeRoleExternalID":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleExternalID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "keyAWSAssumeRoleRoleARN":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keyAWSAssumeRoleRoleARN(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "keySecretKey":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys_keySecretKey(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var github__com___kloudlite___operator___apis___clusters___v1__ClusterOutputImplementors = []string{"Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput"}
 
 func (ec *executionContext) _Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput(ctx context.Context, sel ast.SelectionSet, obj *model.GithubComKloudliteOperatorApisClustersV1ClusterOutput) graphql.Marshaler {
@@ -26246,6 +26434,10 @@ func (ec *executionContext) _Github__com___kloudlite___operator___apis___cluster
 		case "clusterTokenRef":
 
 			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_clusterTokenRef(ctx, field, obj)
+
+		case "credentialKeys":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec_credentialKeys(ctx, field, obj)
 
 		case "credentialsRef":
 
@@ -26798,6 +26990,47 @@ func (ec *executionContext) _Github__com___kloudlite___operator___pkg___raw____j
 		case "RawMessage":
 
 			out.Values[i] = ec._Github__com___kloudlite___operator___pkg___raw____json__RawJson_RawMessage(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var kloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsImplementors = []string{"Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials"}
+
+func (ec *executionContext) _Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials(ctx context.Context, sel ast.SelectionSet, obj *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, kloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials")
+		case "accessKey":
+
+			out.Values[i] = ec._Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_accessKey(ctx, field, obj)
+
+		case "awsAccountId":
+
+			out.Values[i] = ec._Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAccountId(ctx, field, obj)
+
+		case "awsAssumeRoleExternalId":
+
+			out.Values[i] = ec._Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleExternalId(ctx, field, obj)
+
+		case "awsAssumeRoleRoleARN":
+
+			out.Values[i] = ec._Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_awsAssumeRoleRoleARN(ctx, field, obj)
+
+		case "secretKey":
+
+			out.Values[i] = ec._Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials_secretKey(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -29334,22 +29567,6 @@ func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.Selec
 	return res
 }
 
-func (ec *executionContext) unmarshalNKloudlite__io___apps___infra___internal___entities__CloudProviderName2kloudliteᚗioᚋappsᚋinfraᚋinternalᚋentitiesᚐCloudProviderName(ctx context.Context, v interface{}) (entities.CloudProviderName, error) {
-	tmp, err := graphql.UnmarshalString(v)
-	res := entities.CloudProviderName(tmp)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNKloudlite__io___apps___infra___internal___entities__CloudProviderName2kloudliteᚗioᚋappsᚋinfraᚋinternalᚋentitiesᚐCloudProviderName(ctx context.Context, sel ast.SelectionSet, v entities.CloudProviderName) graphql.Marshaler {
-	res := graphql.MarshalString(string(v))
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
 func (ec *executionContext) marshalNKloudlite__io___common__CreatedOrUpdatedBy2kloudliteᚗioᚋcommonᚐCreatedOrUpdatedBy(ctx context.Context, sel ast.SelectionSet, v common.CreatedOrUpdatedBy) graphql.Marshaler {
 	return ec._Kloudlite__io___common__CreatedOrUpdatedBy(ctx, sel, &v)
 }
@@ -30264,6 +30481,13 @@ func (ec *executionContext) unmarshalOGithub__com___kloudlite___operator___apis_
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalOGithub__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐGithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys(ctx context.Context, sel ast.SelectionSet, v *model.GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOGithub__com___kloudlite___operator___apis___clusters___v1__ClusterOutput2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐGithubComKloudliteOperatorApisClustersV1ClusterOutput(ctx context.Context, sel ast.SelectionSet, v *model.GithubComKloudliteOperatorApisClustersV1ClusterOutput) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -30475,20 +30699,19 @@ func (ec *executionContext) marshalOInt2ᚖint64(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) unmarshalOK8s__io___api___core___v1__SecretType2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐK8sIoAPICoreV1SecretType(ctx context.Context, v interface{}) (*model.K8sIoAPICoreV1SecretType, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var res = new(model.K8sIoAPICoreV1SecretType)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOK8s__io___api___core___v1__SecretType2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐK8sIoAPICoreV1SecretType(ctx context.Context, sel ast.SelectionSet, v *model.K8sIoAPICoreV1SecretType) graphql.Marshaler {
+func (ec *executionContext) marshalOKloudlite__io___apps___infra___internal___entities__AWSSecretCredentials2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐKloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials(ctx context.Context, sel ast.SelectionSet, v *model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	return ec._Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOKloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn2ᚖkloudliteᚗioᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐKloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn(ctx context.Context, v interface{}) (*model.KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputKloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOMap2map(ctx context.Context, v interface{}) (map[string]interface{}, error) {

--- a/apps/infra/internal/app/graph/model/models_gen.go
+++ b/apps/infra/internal/app/graph/model/models_gen.go
@@ -24,8 +24,8 @@ type BYOCClusterPaginatedRecords struct {
 }
 
 type CheckAwsAccessOutput struct {
-	Result          bool    `json:"result"`
-	InstallationURL *string `json:"installationUrl,omitempty"`
+	Result          bool        `json:"result"`
+	InstallationURL interface{} `json:"installationUrl,omitempty"`
 }
 
 type CloudProviderSecretEdge struct {
@@ -62,18 +62,15 @@ type DomainEntryPaginatedRecords struct {
 }
 
 type GithubComKloudliteOperatorApisClustersV1AWSClusterConfig struct {
-	AwsAccountID                    string                                                       `json:"awsAccountId"`
-	AwsAssumeRoleParamExternalIDRef *GithubComKloudliteOperatorApisCommonTypesSecretKeyRef       `json:"awsAssumeRoleParamExternalIdRef,omitempty"`
-	K3sMasters                      *GithubComKloudliteOperatorApisClustersV1AWSK3sMastersConfig `json:"k3sMasters,omitempty"`
-	NodePools                       map[string]interface{}                                       `json:"nodePools,omitempty"`
-	Region                          string                                                       `json:"region"`
-	SpotNodePools                   map[string]interface{}                                       `json:"spotNodePools,omitempty"`
+	K3sMasters    *GithubComKloudliteOperatorApisClustersV1AWSK3sMastersConfig `json:"k3sMasters,omitempty"`
+	NodePools     map[string]interface{}                                       `json:"nodePools,omitempty"`
+	Region        string                                                       `json:"region"`
+	SpotNodePools map[string]interface{}                                       `json:"spotNodePools,omitempty"`
 }
 
 type GithubComKloudliteOperatorApisClustersV1AWSClusterConfigIn struct {
-	AwsAccountID string                                                         `json:"awsAccountId"`
-	K3sMasters   *GithubComKloudliteOperatorApisClustersV1AWSK3sMastersConfigIn `json:"k3sMasters,omitempty"`
-	Region       string                                                         `json:"region"`
+	K3sMasters *GithubComKloudliteOperatorApisClustersV1AWSK3sMastersConfigIn `json:"k3sMasters,omitempty"`
+	Region     string                                                         `json:"region"`
 }
 
 type GithubComKloudliteOperatorApisClustersV1AWSK3sMastersConfig struct {
@@ -196,6 +193,14 @@ type GithubComKloudliteOperatorApisClustersV1BYOCSpecIn struct {
 	StorageClasses     []string `json:"storageClasses,omitempty"`
 }
 
+type GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys struct {
+	KeyAccessKey               string `json:"keyAccessKey"`
+	KeyAWSAccountID            string `json:"keyAWSAccountId"`
+	KeyAWSAssumeRoleExternalID string `json:"keyAWSAssumeRoleExternalID"`
+	KeyAWSAssumeRoleRoleArn    string `json:"keyAWSAssumeRoleRoleARN"`
+	KeySecretKey               string `json:"keySecretKey"`
+}
+
 type GithubComKloudliteOperatorApisClustersV1ClusterOutput struct {
 	KeyK3sAgentJoinToken  string `json:"keyK3sAgentJoinToken"`
 	KeyK3sServerJoinToken string `json:"keyK3sServerJoinToken"`
@@ -204,21 +209,22 @@ type GithubComKloudliteOperatorApisClustersV1ClusterOutput struct {
 }
 
 type GithubComKloudliteOperatorApisClustersV1ClusterSpec struct {
-	AccountID              string                                                              `json:"accountId"`
-	AccountName            string                                                              `json:"accountName"`
-	AvailabilityMode       GithubComKloudliteOperatorApisClustersV1ClusterSpecAvailabilityMode `json:"availabilityMode"`
-	Aws                    *GithubComKloudliteOperatorApisClustersV1AWSClusterConfig           `json:"aws,omitempty"`
-	BackupToS3Enabled      bool                                                                `json:"backupToS3Enabled"`
-	CloudflareEnabled      *bool                                                               `json:"cloudflareEnabled,omitempty"`
-	CloudProvider          GithubComKloudliteOperatorApisCommonTypesCloudProvider              `json:"cloudProvider"`
-	ClusterInternalDNSHost *string                                                             `json:"clusterInternalDnsHost,omitempty"`
-	ClusterTokenRef        *GithubComKloudliteOperatorApisCommonTypesSecretKeyRef              `json:"clusterTokenRef,omitempty"`
-	CredentialsRef         *GithubComKloudliteOperatorApisCommonTypesSecretRef                 `json:"credentialsRef"`
-	KloudliteRelease       string                                                              `json:"kloudliteRelease"`
-	MessageQueueTopicName  string                                                              `json:"messageQueueTopicName"`
-	Output                 *GithubComKloudliteOperatorApisClustersV1ClusterOutput              `json:"output,omitempty"`
-	PublicDNSHost          string                                                              `json:"publicDNSHost"`
-	TaintMasterNodes       bool                                                                `json:"taintMasterNodes"`
+	AccountID              string                                                               `json:"accountId"`
+	AccountName            string                                                               `json:"accountName"`
+	AvailabilityMode       GithubComKloudliteOperatorApisClustersV1ClusterSpecAvailabilityMode  `json:"availabilityMode"`
+	Aws                    *GithubComKloudliteOperatorApisClustersV1AWSClusterConfig            `json:"aws,omitempty"`
+	BackupToS3Enabled      bool                                                                 `json:"backupToS3Enabled"`
+	CloudflareEnabled      *bool                                                                `json:"cloudflareEnabled,omitempty"`
+	CloudProvider          GithubComKloudliteOperatorApisCommonTypesCloudProvider               `json:"cloudProvider"`
+	ClusterInternalDNSHost *string                                                              `json:"clusterInternalDnsHost,omitempty"`
+	ClusterTokenRef        *GithubComKloudliteOperatorApisCommonTypesSecretKeyRef               `json:"clusterTokenRef,omitempty"`
+	CredentialKeys         *GithubComKloudliteOperatorApisClustersV1CloudProviderCredentialKeys `json:"credentialKeys,omitempty"`
+	CredentialsRef         *GithubComKloudliteOperatorApisCommonTypesSecretRef                  `json:"credentialsRef"`
+	KloudliteRelease       string                                                               `json:"kloudliteRelease"`
+	MessageQueueTopicName  string                                                               `json:"messageQueueTopicName"`
+	Output                 *GithubComKloudliteOperatorApisClustersV1ClusterOutput               `json:"output,omitempty"`
+	PublicDNSHost          string                                                               `json:"publicDNSHost"`
+	TaintMasterNodes       bool                                                                 `json:"taintMasterNodes"`
 }
 
 type GithubComKloudliteOperatorApisClustersV1ClusterSpecIn struct {
@@ -317,6 +323,20 @@ type GithubComKloudliteOperatorApisWireguardV1PortIn struct {
 
 type GithubComKloudliteOperatorPkgRawJSONRawJSON struct {
 	RawMessage interface{} `json:"RawMessage,omitempty"`
+}
+
+type KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentials struct {
+	AccessKey               *string `json:"accessKey,omitempty"`
+	AwsAccountID            *string `json:"awsAccountId,omitempty"`
+	AwsAssumeRoleExternalID *string `json:"awsAssumeRoleExternalId,omitempty"`
+	AwsAssumeRoleRoleArn    *string `json:"awsAssumeRoleRoleARN,omitempty"`
+	SecretKey               *string `json:"secretKey,omitempty"`
+}
+
+type KloudliteIoAppsInfraInternalEntitiesAWSSecretCredentialsIn struct {
+	AccessKey    *string `json:"accessKey,omitempty"`
+	AwsAccountID *string `json:"awsAccountId,omitempty"`
+	SecretKey    *string `json:"secretKey,omitempty"`
 }
 
 type KloudliteIoAppsInfraInternalEntitiesHelmStatusVal struct {
@@ -479,58 +499,5 @@ func (e *GithubComKloudliteOperatorApisCommonTypesCloudProvider) UnmarshalGQL(v 
 }
 
 func (e GithubComKloudliteOperatorApisCommonTypesCloudProvider) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-type K8sIoAPICoreV1SecretType string
-
-const (
-	K8sIoAPICoreV1SecretTypeBootstrapKubernetesIoToken      K8sIoAPICoreV1SecretType = "bootstrap__kubernetes__io___token"
-	K8sIoAPICoreV1SecretTypeKubernetesIoBasicAuth           K8sIoAPICoreV1SecretType = "kubernetes__io___basic____auth"
-	K8sIoAPICoreV1SecretTypeKubernetesIoDockercfg           K8sIoAPICoreV1SecretType = "kubernetes__io___dockercfg"
-	K8sIoAPICoreV1SecretTypeKubernetesIoDockerconfigjson    K8sIoAPICoreV1SecretType = "kubernetes__io___dockerconfigjson"
-	K8sIoAPICoreV1SecretTypeKubernetesIoServiceAccountToken K8sIoAPICoreV1SecretType = "kubernetes__io___service____account____token"
-	K8sIoAPICoreV1SecretTypeKubernetesIoSSHAuth             K8sIoAPICoreV1SecretType = "kubernetes__io___ssh____auth"
-	K8sIoAPICoreV1SecretTypeKubernetesIoTLS                 K8sIoAPICoreV1SecretType = "kubernetes__io___tls"
-	K8sIoAPICoreV1SecretTypeOpaque                          K8sIoAPICoreV1SecretType = "Opaque"
-)
-
-var AllK8sIoAPICoreV1SecretType = []K8sIoAPICoreV1SecretType{
-	K8sIoAPICoreV1SecretTypeBootstrapKubernetesIoToken,
-	K8sIoAPICoreV1SecretTypeKubernetesIoBasicAuth,
-	K8sIoAPICoreV1SecretTypeKubernetesIoDockercfg,
-	K8sIoAPICoreV1SecretTypeKubernetesIoDockerconfigjson,
-	K8sIoAPICoreV1SecretTypeKubernetesIoServiceAccountToken,
-	K8sIoAPICoreV1SecretTypeKubernetesIoSSHAuth,
-	K8sIoAPICoreV1SecretTypeKubernetesIoTLS,
-	K8sIoAPICoreV1SecretTypeOpaque,
-}
-
-func (e K8sIoAPICoreV1SecretType) IsValid() bool {
-	switch e {
-	case K8sIoAPICoreV1SecretTypeBootstrapKubernetesIoToken, K8sIoAPICoreV1SecretTypeKubernetesIoBasicAuth, K8sIoAPICoreV1SecretTypeKubernetesIoDockercfg, K8sIoAPICoreV1SecretTypeKubernetesIoDockerconfigjson, K8sIoAPICoreV1SecretTypeKubernetesIoServiceAccountToken, K8sIoAPICoreV1SecretTypeKubernetesIoSSHAuth, K8sIoAPICoreV1SecretTypeKubernetesIoTLS, K8sIoAPICoreV1SecretTypeOpaque:
-		return true
-	}
-	return false
-}
-
-func (e K8sIoAPICoreV1SecretType) String() string {
-	return string(e)
-}
-
-func (e *K8sIoAPICoreV1SecretType) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = K8sIoAPICoreV1SecretType(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid K8s__io___api___core___v1__SecretType", str)
-	}
-	return nil
-}
-
-func (e K8sIoAPICoreV1SecretType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/apps/infra/internal/app/graph/schema.graphqls
+++ b/apps/infra/internal/app/graph/schema.graphqls
@@ -51,7 +51,7 @@ type CheckAwsAccessOutput {
 
 type Query {
     # unique name suggestions
-    infra_checkNameAvailability(resType: ResType!, clusterName: String, name: String!): CheckNameAvailabilityOutput! @isLoggedIn @hasAccount
+    infra_checkNameAvailability(resType: ResType!, clusterName: String, name: String!): CheckNameAvailabilityOutput! @isLoggedIn 
 
     # clusters
     infra_listClusters(search: SearchCluster, pagination: CursorPaginationIn): ClusterPaginatedRecords @isLoggedInAndVerified @hasAccount
@@ -70,7 +70,7 @@ type Query {
     infra_listDomainEntries(search: SearchDomainEntry, pagination: CursorPaginationIn): DomainEntryPaginatedRecords @isLoggedInAndVerified @hasAccount
     infra_getDomainEntry(domainName: String!): DomainEntry @isLoggedInAndVerified @hasAccount
 
-    infra_checkAwsAccess(accountId: String!): CheckAwsAccessOutput! @isLoggedInAndVerified @hasAccount
+    infra_checkAwsAccess(cloudproviderName: String!): CheckAwsAccessOutput! @isLoggedInAndVerified @hasAccount
 
     infra_listVPNDevices(clusterName: String, search: SearchVPNDevices, pq: CursorPaginationIn): VPNDevicePaginatedRecords @isLoggedInAndVerified @hasAccount
     infra_getVPNDevice(clusterName: String!, name: String!): VPNDevice @isLoggedInAndVerified @hasAccount

--- a/apps/infra/internal/app/graph/schema.resolvers.go
+++ b/apps/infra/internal/app/graph/schema.resolvers.go
@@ -525,19 +525,20 @@ func (r *queryResolver) InfraGetDomainEntry(ctx context.Context, domainName stri
 }
 
 // InfraCheckAwsAccess is the resolver for the infra_checkAwsAccess field.
-func (r *queryResolver) InfraCheckAwsAccess(ctx context.Context, accountID string) (*model.CheckAwsAccessOutput, error) {
-	if err := r.Domain.ValidateAWSAssumeRole(ctx, accountID); err != nil {
-		u, err := r.Domain.GenerateAWSCloudformationTemplateUrl(ctx, accountID)
-		if err != nil {
-			return nil, err
-		}
-		return &model.CheckAwsAccessOutput{
-			Result:          false,
-			InstallationURL: &u,
-		}, err
+func (r *queryResolver) InfraCheckAwsAccess(ctx context.Context, cloudproviderName string) (*model.CheckAwsAccessOutput, error) {
+	ictx, err := toInfraContext(ctx)
+	if err != nil {
+		return nil, err
 	}
+
+	output, err := r.Domain.ValidateProviderSecretAWSAccess(ictx, cloudproviderName)
+	if err != nil {
+		return nil, err
+	}
+
 	return &model.CheckAwsAccessOutput{
-		Result: true,
+		Result:          output.Result,
+		InstallationURL: output.InstallationURL,
 	}, nil
 }
 
@@ -615,5 +616,7 @@ func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResol
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
-type mutationResolver struct{ *Resolver }
-type queryResolver struct{ *Resolver }
+type (
+	mutationResolver struct{ *Resolver }
+	queryResolver    struct{ *Resolver }
+)

--- a/apps/infra/internal/app/graph/struct-to-graphql/cloudprovidersecret.graphqls
+++ b/apps/infra/internal/app/graph/struct-to-graphql/cloudprovidersecret.graphqls
@@ -1,20 +1,15 @@
 type CloudProviderSecret @shareable {
   accountName: String!
-  apiVersion: String!
-  cloudProviderName: Kloudlite__io___apps___infra___internal___entities__CloudProviderName!
+  aws: Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials
+  cloudProviderName: Github__com___kloudlite___operator___apis___common____types__CloudProvider!
   createdBy: Kloudlite__io___common__CreatedOrUpdatedBy!
   creationTime: Date!
-  data: Map
   displayName: String!
   id: String!
-  immutable: Boolean
-  kind: String!
   lastUpdatedBy: Kloudlite__io___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
-  metadata: Metadata @goField(name: "objectMeta")
+  metadata: Metadata! @goField(name: "objectMeta")
   recordVersion: Int!
-  stringData: Map
-  type: K8s__io___api___core___v1__SecretType
   updateTime: Date!
 }
 
@@ -30,12 +25,9 @@ type CloudProviderSecretPaginatedRecords @shareable {
 }
 
 input CloudProviderSecretIn {
-  cloudProviderName: Kloudlite__io___apps___infra___internal___entities__CloudProviderName!
-  data: Map
+  aws: Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn
+  cloudProviderName: Github__com___kloudlite___operator___apis___common____types__CloudProvider!
   displayName: String!
-  immutable: Boolean
-  metadata: MetadataIn
-  stringData: Map
-  type: K8s__io___api___core___v1__SecretType
+  metadata: MetadataIn!
 }
 

--- a/apps/infra/internal/app/graph/struct-to-graphql/common-types.graphqls
+++ b/apps/infra/internal/app/graph/struct-to-graphql/common-types.graphqls
@@ -1,6 +1,4 @@
 type Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfig @shareable {
-  awsAccountId: String!
-  awsAssumeRoleParamExternalIdRef: Github__com___kloudlite___operator___apis___common____types__SecretKeyRef
   k3sMasters: Github__com___kloudlite___operator___apis___clusters___v1__AWSK3sMastersConfig
   nodePools: Map
   region: String!
@@ -70,6 +68,14 @@ type Github__com___kloudlite___operator___apis___clusters___v1__BYOCSpec @sharea
   storageClasses: [String!]
 }
 
+type Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys @shareable {
+  keyAccessKey: String!
+  keyAWSAccountId: String!
+  keyAWSAssumeRoleExternalID: String!
+  keyAWSAssumeRoleRoleARN: String!
+  keySecretKey: String!
+}
+
 type Github__com___kloudlite___operator___apis___clusters___v1__ClusterOutput @shareable {
   keyK3sAgentJoinToken: String!
   keyK3sServerJoinToken: String!
@@ -87,6 +93,7 @@ type Github__com___kloudlite___operator___apis___clusters___v1__ClusterSpec @sha
   cloudProvider: Github__com___kloudlite___operator___apis___common____types__CloudProvider!
   clusterInternalDnsHost: String
   clusterTokenRef: Github__com___kloudlite___operator___apis___common____types__SecretKeyRef
+  credentialKeys: Github__com___kloudlite___operator___apis___clusters___v1__CloudProviderCredentialKeys
   credentialsRef: Github__com___kloudlite___operator___apis___common____types__SecretRef!
   kloudliteRelease: String!
   messageQueueTopicName: String!
@@ -170,6 +177,14 @@ type Github__com___kloudlite___operator___pkg___raw____json__RawJson @shareable 
   RawMessage: Any
 }
 
+type Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentials @shareable {
+  accessKey: String
+  awsAccountId: String
+  awsAssumeRoleExternalId: String
+  awsAssumeRoleRoleARN: String
+  secretKey: String
+}
+
 type Kloudlite__io___apps___infra___internal___entities__HelmStatusVal @shareable {
   isReady: Boolean
   message: String!
@@ -208,7 +223,6 @@ type PageInfo @shareable {
 }
 
 input Github__com___kloudlite___operator___apis___clusters___v1__AWSClusterConfigIn {
-  awsAccountId: String!
   k3sMasters: Github__com___kloudlite___operator___apis___clusters___v1__AWSK3sMastersConfigIn
   region: String!
 }
@@ -315,6 +329,12 @@ input Github__com___kloudlite___operator___apis___wireguard___v1__PortIn {
   targetPort: Int
 }
 
+input Kloudlite__io___apps___infra___internal___entities__AWSSecretCredentialsIn {
+  accessKey: String
+  awsAccountId: String
+  secretKey: String
+}
+
 input MetadataIn {
   annotations: Map
   labels: Map
@@ -332,27 +352,6 @@ enum Github__com___kloudlite___operator___apis___common____types__CloudProvider 
   azure
   do
   gcp
-}
-
-enum K8s__io___api___core___v1__SecretType {
-  bootstrap__kubernetes__io___token
-  kubernetes__io___basic____auth
-  kubernetes__io___dockercfg
-  kubernetes__io___dockerconfigjson
-  kubernetes__io___service____account____token
-  kubernetes__io___ssh____auth
-  kubernetes__io___tls
-  Opaque
-}
-
-enum Kloudlite__io___apps___infra___internal___entities__CloudProviderName {
-  aws
-  azure
-  do
-  gcp
-  oci
-  openstack
-  vmware
 }
 
 enum Kloudlite__io___pkg___types__SyncStatusAction {

--- a/apps/infra/internal/domain/api.go
+++ b/apps/infra/internal/domain/api.go
@@ -16,9 +16,6 @@ type InfraContext struct {
 }
 
 type Domain interface {
-	ValidateAWSAssumeRole(ctx context.Context, awsAccountId string) error
-	GenerateAWSCloudformationTemplateUrl(ctx context.Context, awsAccountId string) (string, error)
-
 	CheckNameAvailability(ctx InfraContext, typeArg ResType, clusterName *string, name string) (*CheckNameAvailabilityOutput, error)
 
 	CreateCluster(ctx InfraContext, cluster entities.Cluster) (*entities.Cluster, error)
@@ -47,6 +44,8 @@ type Domain interface {
 
 	ListProviderSecrets(ctx InfraContext, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.CloudProviderSecret], error)
 	GetProviderSecret(ctx InfraContext, name string) (*entities.CloudProviderSecret, error)
+
+	ValidateProviderSecretAWSAccess(ctx InfraContext, name string) (*AWSAccessValidationOutput, error)
 
 	ListDomainEntries(ctx InfraContext, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.DomainEntry], error)
 	GetDomainEntry(ctx InfraContext, name string) (*entities.DomainEntry, error)

--- a/apps/infra/internal/domain/provider-secrets.go
+++ b/apps/infra/internal/domain/provider-secrets.go
@@ -1,13 +1,16 @@
 package domain
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"strings"
+"github.com/kloudlite/operator/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	ct "github.com/kloudlite/operator/apis/common-types"
 	iamT "kloudlite.io/apps/iam/types"
 	"kloudlite.io/common"
+	fn "kloudlite.io/pkg/functions"
 
 	"kloudlite.io/apps/infra/internal/entities"
 	"kloudlite.io/pkg/repos"
@@ -17,37 +20,38 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (d *domain) GenerateAWSCloudformationTemplateUrl(ctx context.Context, awsAccountId string) (string, error) {
-	// TODO: generated installation template url,should be unique for a user, which means externalId should be different for each account
+var assumeRoleRoleNameFormat = "kloudlite-access-role-%s"
 
-	var result strings.Builder
+func (d *domain) generateAWSCloudformationTemplateUrl(ctx context.Context, stackName string, paramExternalID string, paramRoleName string) (string, error) {
+	result := bytes.NewBuffer(nil)
 
-	result.WriteString("https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?")
-	result.WriteString(fmt.Sprintf("templateURL=%s", d.env.AWSCloudformationStackS3URL))
-	result.WriteString(fmt.Sprintf("&stackName=%s", d.env.AWSCloudformationStackName))
-	result.WriteString(fmt.Sprintf("&param_ExternalId=%s", d.env.AWSCloudformationParamExternalId))
-	result.WriteString(fmt.Sprintf("&param_TrustedArn=%s", d.env.AWSCloudformationParamTrustedARN))
+	fmt.Fprintf(result, "https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?")
+	fmt.Fprintf(result, "templateURL=%s", d.env.AWSCloudformationStackS3URL)
+	fmt.Fprintf(result, "&stackName=%s", stackName)
+	fmt.Fprintf(result, "&param_ExternalId=%s", paramExternalID)
+	fmt.Fprintf(result, "&param_TrustedArn=%s", d.env.AWSCloudformationParamTrustedARN)
+	fmt.Fprintf(result, "&param_RoleName=%s", paramRoleName)
 
-	return result.String(), nil
+	installationURL := result.String()
+	return installationURL, nil
 }
 
-func (d *domain) ValidateAWSAssumeRole(ctx context.Context, awsAccountId string) error {
+func (d *domain) validateAWSAssumeRole(ctx context.Context, awsAccountId string, paramExternalId string) error {
 	sess, err := session.NewSession()
 	if err != nil {
 		d.logger.Errorf(err, "while creating new session")
 		return err
 	}
 
-	roleARN := fmt.Sprintf(d.env.AWSAssumeTenantRoleFormatString, awsAccountId)
-
 	svc := sts.New(sess)
 
 	resp, err := svc.AssumeRole(&sts.AssumeRoleInput{
-		RoleArn: aws.String(roleARN),
+		RoleArn: aws.String(fmt.Sprintf(d.env.AWSAssumeTenantRoleFormatString, awsAccountId)),
 		// WARN: external id should be different for each tenant
-		ExternalId:      aws.String(d.env.AWSCloudformationParamExternalId),
+		ExternalId:      aws.String(paramExternalId),
 		RoleSessionName: aws.String("TestSession"),
 	})
 	if err != nil {
@@ -60,6 +64,73 @@ func (d *domain) ValidateAWSAssumeRole(ctx context.Context, awsAccountId string)
 	}
 
 	return nil
+}
+
+type AWSAccessValidationOutput struct {
+	Result          bool
+	InstallationURL *string
+}
+
+func (d *domain) ValidateProviderSecretAWSAccess(ctx InfraContext, name string) (*AWSAccessValidationOutput, error) {
+	if err := d.canPerformActionInAccount(ctx, iamT.CreateCloudProviderSecret); err != nil {
+		return nil, err
+	}
+
+	psecret, err := d.findProviderSecret(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := psecret.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := d.validateAWSAssumeRole(ctx, *psecret.AWS.AWSAccountId, psecret.AWS.AWSAssumeRoleExternalId); err != nil {
+		installationURL, err := d.generateAWSCloudformationTemplateUrl(ctx, fmt.Sprintf("%s-%s", d.env.AWSCloudformationStackNamePrefix, psecret.Id), psecret.AWS.AWSAssumeRoleExternalId, fmt.Sprintf(assumeRoleRoleNameFormat, psecret.Id))
+		if err != nil {
+			return nil, err
+		}
+		return &AWSAccessValidationOutput{
+			Result:          false,
+			InstallationURL: &installationURL,
+		}, nil
+	}
+
+	return &AWSAccessValidationOutput{
+		Result:          true,
+		InstallationURL: nil,
+	}, err
+}
+
+func corev1SecretFromProviderSecret(ps *entities.CloudProviderSecret) *corev1.Secret {
+	stringData := map[string]string{}
+	if ps.AWS.AccessKey != nil {
+		stringData[entities.AccessKey] = *ps.AWS.AccessKey
+	}
+	if ps.AWS.SecretKey != nil {
+		stringData[entities.SecretKey] = *ps.AWS.SecretKey
+	}
+	if ps.AWS.AWSAccountId != nil {
+		stringData[entities.AWSAccountId] = *ps.AWS.AWSAccountId
+	}
+	if ps.AWS.AWSAssumeRoleExternalId != "" {
+		stringData[entities.AWSAssumeRoleExternalId] = ps.AWS.AWSAssumeRoleExternalId
+	}
+	if ps.AWS.AWAssumeRoleRoleARN != "" {
+		stringData[entities.AWAssumeRoleRoleARN] = ps.AWS.AWAssumeRoleRoleARN
+	}
+
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ps.Name,
+			Namespace: ps.Namespace,
+			Annotations: map[string]string{
+				constants.DescriptionKey: fmt.Sprintf("created by cloudprovider secret %s", ps.Name),
+			},
+		},
+		StringData: stringData,
+	}
 }
 
 func (d *domain) CreateProviderSecret(ctx InfraContext, pSecret entities.CloudProviderSecret) (*entities.CloudProviderSecret, error) {
@@ -75,20 +146,28 @@ func (d *domain) CreateProviderSecret(ctx InfraContext, pSecret entities.CloudPr
 	pSecret.AccountName = ctx.AccountName
 	pSecret.Namespace = accNs
 
-	if isValid, err := pSecret.Validate(); !isValid && err != nil {
+	if err := pSecret.Validate(); err != nil {
 		return nil, err
 	}
 
-	pSecret.SetGroupVersionKind(schema.FromAPIVersionAndKind("v1", "Secret"))
 	pSecret.IncrementRecordVersion()
 	pSecret.CreatedBy = common.CreatedOrUpdatedBy{
 		UserId:    ctx.UserId,
 		UserName:  ctx.UserName,
 		UserEmail: ctx.UserEmail,
 	}
-	pSecret.LastUpdatedBy = pSecret.CreatedBy
 
-	if err := d.applyK8sResource(ctx, &pSecret.Secret, pSecret.RecordVersion); err != nil {
+	pSecret.LastUpdatedBy = pSecret.CreatedBy
+	pSecret.Id = d.secretRepo.NewId()
+	if pSecret.CloudProviderName == ct.CloudProviderAWS {
+		pSecret.AWS.AWAssumeRoleRoleARN = fmt.Sprintf(d.env.AWSAssumeTenantRoleFormatString,
+			*pSecret.AWS.AWSAccountId,
+			fmt.Sprintf(assumeRoleRoleNameFormat, pSecret.Id),
+		)
+		pSecret.AWS.AWSAssumeRoleExternalId = fn.CleanerNanoidOrDie(40)
+	}
+
+	if err := d.applyK8sResource(ctx, corev1SecretFromProviderSecret(&pSecret), pSecret.RecordVersion); err != nil {
 		return nil, err
 	}
 
@@ -100,39 +179,44 @@ func (d *domain) CreateProviderSecret(ctx InfraContext, pSecret entities.CloudPr
 	return nSecret, nil
 }
 
-func (d *domain) UpdateProviderSecret(ctx InfraContext, secret entities.CloudProviderSecret) (*entities.CloudProviderSecret, error) {
+func (d *domain) UpdateProviderSecret(ctx InfraContext, ups entities.CloudProviderSecret) (*entities.CloudProviderSecret, error) {
 	if err := d.canPerformActionInAccount(ctx, iamT.UpdateCloudProviderSecret); err != nil {
 		return nil, err
 	}
 
-	if isValid, err := secret.Validate(); !isValid && err != nil {
+	if err := ups.Validate(); err != nil {
 		return nil, err
 	}
 
-	scrt, err := d.findProviderSecret(ctx, secret.Name)
+	currScrt, err := d.findProviderSecret(ctx, ups.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	scrt.SetGroupVersionKind(schema.FromAPIVersionAndKind("v1", "Secret"))
-	scrt.IncrementRecordVersion()
-	scrt.LastUpdatedBy = common.CreatedOrUpdatedBy{
+	currScrt.IncrementRecordVersion()
+	currScrt.LastUpdatedBy = common.CreatedOrUpdatedBy{
 		UserId:    ctx.UserId,
 		UserName:  ctx.UserName,
 		UserEmail: ctx.UserEmail,
 	}
 
-	scrt.Labels = secret.Labels
-	scrt.Annotations = secret.Annotations
-	scrt.Data = secret.Data
-	scrt.StringData = secret.StringData
+	currScrt.Labels = ups.Labels
+	currScrt.Annotations = ups.Annotations
 
-	uScrt, err := d.secretRepo.UpdateById(ctx, scrt.Id, scrt)
+	switch ups.CloudProviderName {
+	case ct.CloudProviderAWS:
+		{
+			currScrt.AWS.AccessKey = ups.AWS.AccessKey
+			currScrt.AWS.SecretKey = ups.AWS.SecretKey
+		}
+	}
+
+	uScrt, err := d.secretRepo.UpdateById(ctx, currScrt.Id, currScrt)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := d.applyK8sResource(ctx, &uScrt.Secret, uScrt.RecordVersion); err != nil {
+	if err := d.applyK8sResource(ctx, corev1SecretFromProviderSecret(currScrt), uScrt.RecordVersion); err != nil {
 		return nil, err
 	}
 
@@ -162,7 +246,7 @@ func (d *domain) DeleteProviderSecret(ctx InfraContext, secretName string) error
 		return fmt.Errorf("cloud provider secret %q is used by %d cluster(s), deletion is forbidden", secretName, len(clusters))
 	}
 
-	if err := d.deleteK8sResource(ctx, &cps.Secret); err != nil {
+	if err := d.deleteK8sResource(ctx, corev1SecretFromProviderSecret(cps)); err != nil {
 		return err
 	}
 	return d.secretRepo.DeleteById(ctx, cps.Id)

--- a/apps/infra/internal/entities/provider-secret.go
+++ b/apps/infra/internal/entities/provider-secret.go
@@ -3,39 +3,43 @@ package entities
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
+	ct "github.com/kloudlite/operator/apis/common-types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kloudlite.io/common"
 	"kloudlite.io/pkg/repos"
 )
 
-type CloudProviderName string
-
 const (
-	CloudProviderNameDo        CloudProviderName = "do"
-	CloudProviderNameAws       CloudProviderName = "aws"
-	CloudProviderNameAzure     CloudProviderName = "azure"
-	CloudProviderNameGcp       CloudProviderName = "gcp"
-	CloudProviderNameOci       CloudProviderName = "oci"
-	CloudProviderNameOpenstack CloudProviderName = "openstack"
-	CloudProviderNameVmware    CloudProviderName = "vmware"
+	AccessKey string = "accessKey"
+	SecretKey string = "secretKey"
+
+	AWSAccountId            string = "awsAccountId"
+	AWSAssumeRoleExternalId string = "awsAssumeRoleExternalId"
+	AWAssumeRoleRoleARN     string = "awsAssumeRoleRoleARN"
 )
 
-const (
-	AccessKey    string = "accessKey"
-	AccessSecret string = "accessSecret"
-)
+type AWSSecretCredentials struct {
+	AWSAccountId            *string `json:"awsAccountId,omitempty"`
+	AWSAssumeRoleExternalId string  `json:"awsAssumeRoleExternalId,omitempty" graphql:"noinput"`
+	AWAssumeRoleRoleARN     string  `json:"awsAssumeRoleRoleARN,omitempty" graphql:"noinput"`
+
+	AccessKey *string `json:"accessKey,omitempty"`
+	SecretKey *string `json:"secretKey,omitempty"`
+}
 
 type CloudProviderSecret struct {
-	repos.BaseEntity  `json:",inline" graphql:"noinput"`
-	corev1.Secret     `json:",inline" graphql:"uri=k8s://secrets.crds.kloudlite.io"`
-	CloudProviderName CloudProviderName `json:"cloudProviderName"`
+	repos.BaseEntity `json:",inline" graphql:"noinput"`
+	// corev1.Secret     `json:",inline" graphql:"uri=k8s://secrets.crds.kloudlite.io"`
+	metav1.ObjectMeta `json:"metadata"`
+	CloudProviderName ct.CloudProvider `json:"cloudProviderName"`
 
 	common.ResourceMetadata `json:",inline"`
+	AWS                     *AWSSecretCredentials `json:"aws,omitempty"`
 
 	AccountName string `json:"accountName" graphql:"noinput"`
 }
 
-var SecretIndices = []repos.IndexField{
+var CloudProviderSecretIndices = []repos.IndexField{
 	{
 		Field: []repos.IndexKey{
 			{Key: "id", Value: repos.IndexAsc},
@@ -60,14 +64,28 @@ var SecretIndices = []repos.IndexField{
 	},
 }
 
-func (cps *CloudProviderSecret) Validate() (bool, error) {
+func (cps *CloudProviderSecret) Validate() error {
 	if cps == nil {
-		return false, fmt.Errorf("cloud provider secret is nil")
+		return fmt.Errorf("cloud provider secret is nil")
 	}
 
-	if cps.StringData[AccessKey] == "" || cps.StringData[AccessSecret] == "" {
-		return false, fmt.Errorf(".stringData.accessKey or .stringData.accessSecret is empty")
+	switch cps.CloudProviderName {
+	case ct.CloudProviderAWS:
+		{
+			if cps.AWS == nil {
+				return fmt.Errorf(".aws is nil, must be provided when cloudproviderName is set to aws")
+			}
+			if cps.AWS.AWSAccountId == nil && (cps.AWS.AccessKey == nil || cps.AWS.SecretKey == nil) {
+				return fmt.Errorf("neither .aws.%s nor (.aws.%s and .aws.%s) is provided", AWSAccountId, AccessKey, SecretKey)
+			}
+		}
+	default:
+		{
+			// if cps.StringData[AccessKey] == "" || cps.StringData[SecretKey] == "" {
+			// 	return false, fmt.Errorf(".stringData.accessKey or .stringData.accessSecret is empty")
+			// }
+		}
 	}
 
-	return true, nil
+	return nil
 }

--- a/apps/infra/internal/env/env.go
+++ b/apps/infra/internal/env/env.go
@@ -38,9 +38,8 @@ type Env struct {
 
 	AWSAssumeTenantRoleFormatString string `env:"AWS_ASSUME_TENANT_ROLE_FORMAT_STRING" required:"true"`
 
-	AWSCloudformationParamExternalId string `env:"AWS_CLOUDFORMATION_PARAM_EXTERNAL_ID" required:"true"`
 	AWSCloudformationParamTrustedARN string `env:"AWS_CLOUDFORMATION_PARAM_TRUSTED_ARN" required:"true"`
-	AWSCloudformationStackName       string `env:"AWS_CLOUDFORMATION_STACK_NAME" required:"true"`
+	AWSCloudformationStackNamePrefix string `env:"AWS_CLOUDFORMATION_STACK_NAME_PREFIX" required:"true"`
 	AWSCloudformationStackS3URL      string `env:"AWS_CLOUDFORMATION_STACK_S3_URL" required:"true"`
 
 	AWSAccessKey string `env:"AWS_ACCESS_KEY" required:"true"`

--- a/pkg/functions/utils.go
+++ b/pkg/functions/utils.go
@@ -43,4 +43,3 @@ func New[T any](v T) *T {
 func RegularPlural(singular string) string {
 	return flect.Pluralize(strings.ToLower(singular))
 }
-


### PR DESCRIPTION
- cloudprovider secret creation is now fully typed, does not embed corev1.Secret, so no need to have dynamic fields in secret.StringData. Fully typed and better validation

- aws cloudformation configurations are directly provided (and merged by graphql resolvers) while, performing the cloudprovider secret creation. With this we ensure that for every cloudprovider secret, we can create an aws cloudformation stack with different stack names, roles, and iam instance profiles