### PR TITLE
feat(infra): fixes cluster status updates, and deletions

### DIFF
--- a/apps/infra/internal/app/graph/schema.resolvers.go
+++ b/apps/infra/internal/app/graph/schema.resolvers.go
@@ -7,6 +7,7 @@ package graph
 import (
 	"context"
 	"encoding/base64"
+
 	"github.com/kloudlite/api/apps/infra/internal/app/graph/generated"
 	"github.com/kloudlite/api/apps/infra/internal/app/graph/model"
 	"github.com/kloudlite/api/apps/infra/internal/domain"
@@ -729,5 +730,7 @@ func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResol
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
-type mutationResolver struct{ *Resolver }
-type queryResolver struct{ *Resolver }
+type (
+	mutationResolver struct{ *Resolver }
+	queryResolver    struct{ *Resolver }
+)

--- a/apps/infra/internal/domain/domain.go
+++ b/apps/infra/internal/domain/domain.go
@@ -2,9 +2,10 @@ package domain
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/kloudlite/api/pkg/errors"
 	"github.com/kloudlite/api/pkg/k8s"
-	"strconv"
 
 	"github.com/kloudlite/api/apps/infra/internal/entities"
 
@@ -21,8 +22,6 @@ import (
 	types "github.com/kloudlite/api/pkg/types"
 )
 
-
-
 type domain struct {
 	logger logging.Logger
 	env    *env.Env
@@ -37,9 +36,9 @@ type domain struct {
 	pvcRepo         repos.DbRepo[*entities.PersistentVolumeClaim]
 	buildRunRepo    repos.DbRepo[*entities.BuildRun]
 
-	//k8sClient k8s.Client
+	// k8sClient k8s.Client
 
-	//producer messaging.Producer
+	// producer messaging.Producer
 
 	iamClient                   iam.IAMClient
 	accountsSvc                 AccountsSvc
@@ -47,8 +46,6 @@ type domain struct {
 	resDispatcher               ResourceDispatcher
 	k8sClient                   k8s.Client
 }
-
-
 
 func (d *domain) resyncToTargetCluster(ctx InfraContext, action types.SyncAction, clusterName string, obj client.Object, recordVersion int) error {
 	switch action {
@@ -156,19 +153,19 @@ var Module = fx.Module("domain",
 			logger logging.Logger,
 		) Domain {
 			return &domain{
-				logger: logger,
-				env:    env,
-				clusterRepo:     clusterRepo,
-				byocClusterRepo: byocClusterRepo,
-				nodeRepo:        nodeRepo,
-				nodePoolRepo:    nodePoolRepo,
-				secretRepo:      secretRepo,
-				domainEntryRepo: domainNameRepo,
-				vpnDeviceRepo:   vpnDeviceRepo,
-				pvcRepo:         pvcRepo,
-				buildRunRepo:    buildRunRepo,
-				resDispatcher :  resourceDispatcher,
-				k8sClient: k8sClient,
+				logger:                      logger,
+				env:                         env,
+				clusterRepo:                 clusterRepo,
+				byocClusterRepo:             byocClusterRepo,
+				nodeRepo:                    nodeRepo,
+				nodePoolRepo:                nodePoolRepo,
+				secretRepo:                  secretRepo,
+				domainEntryRepo:             domainNameRepo,
+				vpnDeviceRepo:               vpnDeviceRepo,
+				pvcRepo:                     pvcRepo,
+				buildRunRepo:                buildRunRepo,
+				resDispatcher:               resourceDispatcher,
+				k8sClient:                   k8sClient,
 				iamClient:                   iamClient,
 				accountsSvc:                 accountsSvc,
 				messageOfficeInternalClient: msgOfficeInternalClient,

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -122,8 +122,9 @@ func (c *clientHandler) DeleteYAML(ctx context.Context, yamls ...[]byte) error {
 func NewClient(cfg *rest.Config, scheme *runtime.Scheme) (Client, error) {
 	if scheme == nil {
 		scheme = runtime.NewScheme()
-		clientgoscheme.AddToScheme(scheme)
 	}
+
+	clientgoscheme.AddToScheme(scheme)
 
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,


### PR DESCRIPTION
- cluster status updates are now fetched from k8s api, instead of resource-watcher
- cluster deletion is now done in 2 steps: + on delete request, k8s cluster resource is deleted, and it goes into its finalizing phase + and, while listing or getting the resource, we check if resource is deleted, and it if it is, then that result is omitted
