### PR TITLE
feat(infra): fixes update for nodepool and cluster resources

### DIFF
--- a/apps/infra/internal/domain/clusters.go
+++ b/apps/infra/internal/domain/clusters.go
@@ -361,7 +361,9 @@ func (d *domain) UpdateCluster(ctx InfraContext, cluster entities.Cluster) (*ent
 		UserEmail: ctx.UserEmail,
 	}
 
-	clus.Spec = cluster.Spec
+  // FIXME: no update for cluster spec
+	// clus.Spec = cluster.Spec
+
 	clus.Labels = cluster.Labels
 	clus.Annotations = cluster.Annotations
 	clus.SyncStatus = t.GenSyncStatus(t.SyncActionApply, clus.RecordVersion)


### PR DESCRIPTION
## Description

fixes, update for nodepool and cluster resources
  - earlier, graphql update to nodepool and cluster resources were overriding the entire spec for the resources, which resulted in data loss and in failed reconcilations for those resources