### PR TITLE
fix(infra): updates resource updates from agent processing

### DIFF
--- a/apps/infra/internal/app/process-error-on-apply.go
+++ b/apps/infra/internal/app/process-error-on-apply.go
@@ -50,15 +50,15 @@ func ProcessErrorOnApply(consumer ErrorOnApplyConsumer, logger logging.Logger, d
 		switch obj.GroupVersionKind().String() {
 		case nodepoolGVK.String():
 			{
-				return d.OnNodepoolApplyError(dctx, errMsg.ClusterName, obj.GetName(), errMsg.Error)
+				return d.OnNodepoolApplyError(dctx, errMsg.ClusterName, obj.GetName(), errMsg.Error, domain.UpdateAndDeleteOpts{MessageTimestamp: msg.Timestamp})
 			}
 		case deviceGVK.String():
 			{
-				return d.OnVPNDeviceApplyError(dctx, errMsg.ClusterName, obj.GetName(), errMsg.Error)
+				return d.OnVPNDeviceApplyError(dctx, errMsg.ClusterName, obj.GetName(), errMsg.Error, domain.UpdateAndDeleteOpts{MessageTimestamp: msg.Timestamp})
 			}
 		case clusterMsvcGVK.String():
 			{
-				return d.OnClusterManagedServiceApplyError(dctx, errMsg.ClusterName, obj.GetName(), errMsg.Error)
+				return d.OnClusterManagedServiceApplyError(dctx, errMsg.ClusterName, obj.GetName(), errMsg.Error, domain.UpdateAndDeleteOpts{MessageTimestamp: msg.Timestamp})
 			}
 		default:
 			{

--- a/apps/infra/internal/domain/api.go
+++ b/apps/infra/internal/domain/api.go
@@ -2,9 +2,10 @@ package domain
 
 import (
 	"context"
-
 	"github.com/kloudlite/api/apps/infra/internal/entities"
 	"github.com/kloudlite/api/pkg/repos"
+	"github.com/kloudlite/operator/operators/resource-watcher/types"
+	"time"
 )
 
 type InfraContext struct {
@@ -13,6 +14,10 @@ type InfraContext struct {
 	UserEmail   string
 	UserName    string
 	AccountName string
+}
+
+type UpdateAndDeleteOpts struct {
+	MessageTimestamp time.Time
 }
 
 type Domain interface {
@@ -28,7 +33,7 @@ type Domain interface {
 	GetClusterAdminKubeconfig(ctx InfraContext, clusterName string) (*string, error)
 
 	OnDeleteClusterMessage(ctx InfraContext, cluster entities.Cluster) error
-	OnUpdateClusterMessage(ctx InfraContext, cluster entities.Cluster) error
+	OnUpdateClusterMessage(ctx InfraContext, cluster entities.Cluster, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
 
 	CreateProviderSecret(ctx InfraContext, secret entities.CloudProviderSecret) (*entities.CloudProviderSecret, error)
 	UpdateProviderSecret(ctx InfraContext, secret entities.CloudProviderSecret) (*entities.CloudProviderSecret, error)
@@ -54,8 +59,8 @@ type Domain interface {
 	GetNodePool(ctx InfraContext, clusterName string, poolName string) (*entities.NodePool, error)
 
 	OnDeleteNodePoolMessage(ctx InfraContext, clusterName string, nodePool entities.NodePool) error
-	OnUpdateNodePoolMessage(ctx InfraContext, clusterName string, nodePool entities.NodePool) error
-	OnNodepoolApplyError(ctx InfraContext, clusterName string, name string, errMsg string) error
+	OnUpdateNodePoolMessage(ctx InfraContext, clusterName string, nodePool entities.NodePool, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
+	OnNodepoolApplyError(ctx InfraContext, clusterName string, name string, errMsg string, opts UpdateAndDeleteOpts) error
 
 	ListNodes(ctx InfraContext, clusterName string, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.Node], error)
 	GetNode(ctx InfraContext, clusterName string, nodeName string) (*entities.Node, error)
@@ -71,13 +76,13 @@ type Domain interface {
 	UpdateVPNDevice(ctx InfraContext, clusterName string, device entities.VPNDevice) (*entities.VPNDevice, error)
 	DeleteVPNDevice(ctx InfraContext, clusterName string, name string) error
 
-	OnVPNDeviceApplyError(ctx InfraContext, clusterName string, name string, errMsg string) error
+	OnVPNDeviceApplyError(ctx InfraContext, clusterName string, name string, errMsg string, opts UpdateAndDeleteOpts) error
 	OnVPNDeviceDeleteMessage(ctx InfraContext, clusterName string, device entities.VPNDevice) error
-	OnVPNDeviceUpdateMessage(ctx InfraContext, clusterName string, device entities.VPNDevice) error
+	OnVPNDeviceUpdateMessage(ctx InfraContext, clusterName string, device entities.VPNDevice, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
 
 	ListPVCs(ctx InfraContext, clusterName string, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.PersistentVolumeClaim], error)
 	GetPVC(ctx InfraContext, clusterName string, pvcName string) (*entities.PersistentVolumeClaim, error)
-	OnPVCUpdateMessage(ctx InfraContext, clusterName string, pvc entities.PersistentVolumeClaim) error
+	OnPVCUpdateMessage(ctx InfraContext, clusterName string, pvc entities.PersistentVolumeClaim, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
 	OnPVCDeleteMessage(ctx InfraContext, clusterName string, pvc entities.PersistentVolumeClaim) error
 
 	ListClusterManagedServices(ctx InfraContext, clusterName string, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.ClusterManagedService], error)
@@ -86,7 +91,7 @@ type Domain interface {
 	UpdateClusterManagedService(ctx InfraContext, clusterName string, service entities.ClusterManagedService) (*entities.ClusterManagedService, error)
 	DeleteClusterManagedService(ctx InfraContext, clusterName string, name string) error
 
-	OnClusterManagedServiceApplyError(ctx InfraContext, clusterName string, name string, errMsg string) error
+	OnClusterManagedServiceApplyError(ctx InfraContext, clusterName, name, errMsg string, opts UpdateAndDeleteOpts) error
 	OnClusterManagedServiceDeleteMessage(ctx InfraContext, clusterName string, service entities.ClusterManagedService) error
-	OnClusterManagedServiceUpdateMessage(ctx InfraContext, clusterName string, service entities.ClusterManagedService) error
+	OnClusterManagedServiceUpdateMessage(ctx InfraContext, clusterName string, service entities.ClusterManagedService, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
 }

--- a/apps/infra/internal/domain/cluster-managed-service.go
+++ b/apps/infra/internal/domain/cluster-managed-service.go
@@ -1,8 +1,6 @@
 package domain
 
 import (
-	"time"
-
 	iamT "github.com/kloudlite/api/apps/iam/types"
 	"github.com/kloudlite/api/apps/infra/internal/entities"
 	"github.com/kloudlite/api/common"
@@ -11,6 +9,7 @@ import (
 	"github.com/kloudlite/api/pkg/repos"
 	t "github.com/kloudlite/api/pkg/types"
 	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
+	"github.com/kloudlite/operator/operators/resource-watcher/types"
 )
 
 func (d *domain) ListClusterManagedServices(ctx InfraContext, clusterName string, mf map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.ClusterManagedService], error) {
@@ -182,14 +181,14 @@ func (d *domain) DeleteClusterManagedService(ctx InfraContext, clusterName strin
 	return d.resDispatcher.DeleteFromTargetCluster(ctx, clusterName, &upC.ClusterManagedService)
 }
 
-func (d *domain) OnClusterManagedServiceApplyError(ctx InfraContext, clusterName string, name string, errMsg string) error {
+func (d *domain) OnClusterManagedServiceApplyError(ctx InfraContext, clusterName, name, errMsg string, opts UpdateAndDeleteOpts) error {
 	svc, err := d.findClusterManagedService(ctx, clusterName, name)
 	if err != nil {
 		return errors.NewE(err)
 	}
 
 	svc.SyncStatus.State = t.SyncStateErroredAtAgent
-	svc.SyncStatus.LastSyncedAt = time.Now()
+	svc.SyncStatus.LastSyncedAt = opts.MessageTimestamp
 	svc.SyncStatus.Error = &errMsg
 
 	_, err = d.clusterManagedServiceRepo.UpdateById(ctx, svc.Id, svc)
@@ -213,7 +212,7 @@ func (d *domain) OnClusterManagedServiceDeleteMessage(ctx InfraContext, clusterN
 	return err
 }
 
-func (d *domain) OnClusterManagedServiceUpdateMessage(ctx InfraContext, clusterName string, service entities.ClusterManagedService) error {
+func (d *domain) OnClusterManagedServiceUpdateMessage(ctx InfraContext, clusterName string, service entities.ClusterManagedService, status types.ResourceStatus, opts UpdateAndDeleteOpts) error {
 	svc, err := d.findClusterManagedService(ctx, clusterName, service.Name)
 	if err != nil {
 		return errors.NewE(err)
@@ -225,8 +224,13 @@ func (d *domain) OnClusterManagedServiceUpdateMessage(ctx InfraContext, clusterN
 
 	svc.Status = service.Status
 
-	svc.SyncStatus.State = t.SyncStateReceivedUpdateFromAgent
-	svc.SyncStatus.LastSyncedAt = time.Now()
+	svc.SyncStatus.State = func() t.SyncState {
+		if status == types.ResourceStatusDeleting {
+			return t.SyncStateDeletingAtAgent
+		}
+		return t.SyncStateUpdatedAtAgent
+	}()
+	svc.SyncStatus.LastSyncedAt = opts.MessageTimestamp
 	svc.SyncStatus.Error = nil
 	svc.SyncStatus.RecordVersion = svc.RecordVersion
 

--- a/apps/infra/internal/entities/pvc.go
+++ b/apps/infra/internal/entities/pvc.go
@@ -2,14 +2,16 @@ package entities
 
 import (
 	"github.com/kloudlite/api/pkg/repos"
+	"github.com/kloudlite/api/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 )
 
 type PersistentVolumeClaim struct {
 	repos.BaseEntity             `json:",inline" graphql:"noinput"`
 	corev1.PersistentVolumeClaim `json:",inline" graphql:"noinput"`
-	AccountName                  string `json:"accountName" graphql:"noinput"`
-	ClusterName                  string `json:"clusterName" graphql:"noinput"`
+	AccountName                  string           `json:"accountName" graphql:"noinput"`
+	ClusterName                  string           `json:"clusterName" graphql:"noinput"`
+	SyncStatus                   types.SyncStatus `json:"syncStatus" graphql:"noinput"`
 }
 
 var PersistentVolumeClaimIndices = []repos.IndexField{

--- a/pkg/types/sync-status.go
+++ b/pkg/types/sync-status.go
@@ -29,6 +29,9 @@ const (
 	SyncStateAppliedAtAgent          SyncState = "APPLIED_AT_AGENT"
 	SyncStateErroredAtAgent          SyncState = "ERRORED_AT_AGENT"
 	SyncStateReceivedUpdateFromAgent SyncState = "RECEIVED_UPDATE_FROM_AGENT"
+	SyncStateUpdatedAtAgent          SyncState = "UPDATED_AT_AGENT"
+	SyncStateDeletingAtAgent         SyncState = "DELETING_AT_AGENT"
+	SyncStateDeletedAtAgent          SyncState = "DELETED_AT_AGENT"
 )
 
 func GenSyncStatus(action SyncAction, recordVersion int) SyncStatus {


### PR DESCRIPTION
## Description

- resource updates from agent is now processed only when the resource object has a field set by resource watcher, which signifies the state of current resource, i.e. whether it is being updated, deleting or is deleted