### PR TITLE
fix(console): project cluster KV cache

### DIFF
--- a/.tools/nvim/__http__/console/apps.graphql.yml
+++ b/.tools/nvim/__http__/console/apps.graphql.yml
@@ -16,6 +16,13 @@ query: |+ # graphql
             userId
             userName
           }
+          syncStatus {
+            state
+            action
+            error
+            syncScheduledAt
+            recordVersion
+          }
           projectName
           recordVersion
           kind

--- a/.tools/nvim/__http__/console/environments.graphql.yml
+++ b/.tools/nvim/__http__/console/environments.graphql.yml
@@ -4,7 +4,7 @@ global:
 ---
 
 label: List Environments
-query: |+
+query: |+ #graphql
   query Core_listEnvironments($projectName: String!) {
     core_listEnvironments(projectName: $projectName) {
       edges {
@@ -54,7 +54,7 @@ variables:
 ---
 
 label: Create Environment
-query: |+
+query: |+ #graphql
   mutation Core_createEnvironment($projectName: String!, $env: EnvironmentIn!) {
     core_createEnvironment(projectName: $projectName, env: $env) {
       apiVersion

--- a/apps/console/internal/domain/domain.go
+++ b/apps/console/internal/domain/domain.go
@@ -124,8 +124,10 @@ func (d *domain) applyK8sResource(ctx K8sContext, projectName string, obj client
 		return errors.NewE(err)
 	}
 
+  subject := common.GetTenantClusterMessagingTopic(ctx.GetAccountName(), *clusterName)
+
 	err = d.producer.Produce(ctx, msgTypes.ProduceMsg{
-		Subject: common.GetTenantClusterMessagingTopic(ctx.GetAccountName(), *clusterName),
+		Subject: subject,
 		Payload: b,
 	})
 	return errors.NewE(err)

--- a/apps/console/internal/domain/environment.go
+++ b/apps/console/internal/domain/environment.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+
 	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
 
 	iamT "github.com/kloudlite/api/apps/iam/types"

--- a/apps/console/internal/domain/project.go
+++ b/apps/console/internal/domain/project.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"fmt"
+
 	"github.com/kloudlite/api/pkg/errors"
 	fn "github.com/kloudlite/api/pkg/functions"
 	"github.com/kloudlite/api/pkg/kv"
@@ -20,8 +21,8 @@ import (
 )
 
 func (d *domain) getClusterAttachedToProject(ctx K8sContext, projectName string) (*string, error) {
+	cacheKey := fmt.Sprintf("account_name_%s-project_name_%s", ctx.GetAccountName(), projectName)
 	clusterName, err := d.consoleCacheStore.Get(ctx, projectName)
-
 	if err != nil {
 		if !errors.Is(err, kv.ErrKeyNotFound) {
 			return nil, err
@@ -39,7 +40,7 @@ func (d *domain) getClusterAttachedToProject(ctx K8sContext, projectName string)
 		}
 
 		defer func() {
-			if err := d.consoleCacheStore.Set(ctx, projectName, []byte(fn.DefaultIfNil(proj.ClusterName))); err != nil {
+			if err := d.consoleCacheStore.Set(ctx, cacheKey, []byte(fn.DefaultIfNil(proj.ClusterName))); err != nil {
 				d.logger.Infof("failed to set project cluster map: %v", err)
 			}
 		}()

--- a/apps/message-office/internal/app/app.go
+++ b/apps/message-office/internal/app/app.go
@@ -47,7 +47,7 @@ var Module = fx.Module("app",
 	domain.Module,
 
 	fx.Provide(func(logger logging.Logger, jc *nats.JetstreamClient, producer UpdatesProducer, ev *env.Env, d domain.Domain) (messages.MessageDispatchServiceServer, error) {
-		return NewMessageOfficeServer(producer, jc, ev, d, logger.WithName("message-office-grpc-server"))
+		return NewMessageOfficeServer(producer, jc, ev, d, logger.WithName("message-office"))
 	}),
 
 	fx.Provide(func(conn RealVectorGrpcClient) proto_rpc.VectorClient {
@@ -57,7 +57,7 @@ var Module = fx.Module("app",
 	fx.Provide(func(vectorGrpcClient proto_rpc.VectorClient, logger logging.Logger, d domain.Domain, ev *env.Env) proto_rpc.VectorServer {
 		return &vectorProxyServer{
 			realVectorClient:   vectorGrpcClient,
-			logger:             logger.WithKV("component", "vector-proxy-grpc-server"),
+			logger:             logger.WithName("vector-proxy"),
 			domain:             d,
 			tokenHashingSecret: ev.TokenHashingSecret,
 			pushEventsCounter:  0,


### PR DESCRIPTION
- fixes, incorrect key for project cluster KV cache, it needed to have key composed of `accountName` and `projectName`, but we had it set to `projectName` only, which was a BIG mistake

