### PR TITLE
Fix/ingress domain sync

### DIFF
--- a/apps/infra/internal/domain/api.go
+++ b/apps/infra/internal/domain/api.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	networkingv1 "k8s.io/api/networking/v1"
 	"time"
 
 	"github.com/kloudlite/api/apps/infra/internal/entities"
@@ -124,6 +125,9 @@ type Domain interface {
 	GetPV(ctx InfraContext, clusterName string, pvName string) (*entities.PersistentVolume, error)
 	OnPVUpdateMessage(ctx InfraContext, clusterName string, pv entities.PersistentVolume, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
 	OnPVDeleteMessage(ctx InfraContext, clusterName string, pv entities.PersistentVolume) error
+
+	OnIngressUpdateMessage(ctx InfraContext, clusterName string, ingress networkingv1.Ingress, status types.ResourceStatus, opts UpdateAndDeleteOpts) error
+	OnIngressDeleteMessage(ctx InfraContext, clusterName string, ingress networkingv1.Ingress) error
 
 	ListVolumeAttachments(ctx InfraContext, clusterName string, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.VolumeAttachment], error)
 	GetVolumeAttachment(ctx InfraContext, clusterName string, volAttachmentName string) (*entities.VolumeAttachment, error)

--- a/apps/infra/internal/domain/ingress.go
+++ b/apps/infra/internal/domain/ingress.go
@@ -1,0 +1,54 @@
+package domain
+
+import (
+	"github.com/kloudlite/api/apps/infra/internal/entities"
+	"github.com/kloudlite/api/common"
+	"github.com/kloudlite/api/pkg/repos"
+	"github.com/kloudlite/operator/operators/resource-watcher/types"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func (d *domain) OnIngressUpdateMessage(ctx InfraContext, clusterName string, ingress networkingv1.Ingress, status types.ResourceStatus, opts UpdateAndDeleteOpts) error {
+	for i := range ingress.Spec.Rules {
+		domainName := ingress.Spec.Rules[i].Host
+		if _, err := d.domainEntryRepo.Upsert(ctx, repos.Filter{
+			"accountName": ctx.AccountName,
+			"clusterName": clusterName,
+			"domainName":  domainName,
+		}, &entities.DomainEntry{
+			ResourceMetadata: common.ResourceMetadata{
+				DisplayName:   domainName,
+				CreatedBy:     common.CreatedOrUpdatedByResourceSync,
+				LastUpdatedBy: common.CreatedOrUpdatedByResourceSync,
+			},
+			DomainName:  domainName,
+			AccountName: ctx.AccountName,
+			ClusterName: clusterName,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *domain) OnIngressDeleteMessage(ctx InfraContext, clusterName string, ingress networkingv1.Ingress) error {
+	domainNames := make([]any, 0, len(ingress.Spec.Rules))
+	for i := range ingress.Spec.Rules {
+		domainNames = append(domainNames, ingress.Spec.Rules[i].Host)
+	}
+
+	filter := repos.Filter{
+		"accountName": ctx.AccountName,
+		"clusterName": clusterName,
+	}
+
+	filters := d.domainEntryRepo.MergeMatchFilters(filter, map[string]repos.MatchFilter{
+		"domainName": {
+			MatchType: repos.MatchTypeArray,
+			Array:     domainNames,
+		},
+	})
+
+	return d.domainEntryRepo.DeleteMany(ctx, filters)
+}

--- a/apps/infra/internal/domain/ports.go
+++ b/apps/infra/internal/domain/ports.go
@@ -26,6 +26,7 @@ const (
 
 type ResourceEventPublisher interface {
 	PublishClusterEvent(cluster *entities.Cluster, msg PublishMsg)
+
 	PublishNodePoolEvent(np *entities.NodePool, msg PublishMsg)
 	PublishVpnDeviceEvent(dev *entities.VPNDevice, msg PublishMsg)
 	PublishDomainResEvent(domain *entities.DomainEntry, msg PublishMsg)

--- a/common/types.go
+++ b/common/types.go
@@ -37,3 +37,9 @@ const (
 	CreatedByResourceSyncUserEmail string = "created-by-resource-sync-user-email"
 	CreatedByResourceSyncUserId    string = "created-by-resource-sync-user-id"
 )
+
+var CreatedOrUpdatedByResourceSync = CreatedOrUpdatedBy{
+	UserId:    repos.ID(CreatedByResourceSyncUserId),
+	UserName:  CreatedByResourceSyncUsername,
+	UserEmail: CreatedByResourceSyncUserEmail,
+}


### PR DESCRIPTION
## Description

- ingress resources are now synced back to infra api, which in turn parses the domains listed in the resource, and adds it to domain entries, which are shown to user, when creating a router