### PR TITLE
Fix/resource sync and patches

### DIFF
--- a/.tools/nvim/__http__/console/apps.graphql.yml
+++ b/.tools/nvim/__http__/console/apps.graphql.yml
@@ -93,8 +93,8 @@ variables:
   app:
     displayName: "sample app"
     metadata:
-      # name: "{{.name}}"
-      name: "SAMPLE2"
+      name: "{{.name}}"
+      # name: "SAMPLE2"
     spec:
       services:
         - type: tcp

--- a/.tools/nvim/__http__/console/environments.graphql.yml
+++ b/.tools/nvim/__http__/console/environments.graphql.yml
@@ -128,5 +128,5 @@ query: |+
   }
 variables:
   projectName: "{{.projectName}}"
-  envName: "{{.envName2}}"
+  envName: "{{.envName}}"
 ---

--- a/.tools/nvim/__http__/console/image-pull-secrets.yml
+++ b/.tools/nvim/__http__/console/image-pull-secrets.yml
@@ -1,0 +1,66 @@
+---
+label: List Image Pull Secrets
+query: |+ #graphql
+  query Core_listImagePullSecrets($projectName: String!, $envName: String!) {
+    core_listImagePullSecrets(projectName: $projectName, envName: $envName) {
+      edges {
+        node {
+          format
+          dockerConfigJson
+          environmentName
+        }
+      }
+    }
+  }
+variables:
+  projectName: "{{.projectName}}"
+  envName: "{{.envName}}"
+
+---
+
+query: |+ #graphql
+  mutation Core_createImagePullSecret($projectName: String!, $envName: String!, $imagePullSecretIn: ImagePullSecretIn!) {
+    core_createImagePullSecret(projectName: $projectName, envName: $envName, imagePullSecretIn: $imagePullSecretIn) {
+      format
+      dockerConfigJson
+    }
+  }
+variables:
+  # projectName: "{{.projectName}}"
+  # envName: "{{.envName}}"
+  projectName: "demo-project"
+  envName: "public-environment"
+  imagePullSecretIn:
+    displayName: "Image Pull Secret"
+    metadata:
+      name: test-ips
+    format: dockerConfigJson
+    dockerConfigJson: |+
+      {
+        "auths": {
+          "ghcr.io": {
+            "auth": "************"
+          }
+        }
+      }
+---
+
+query: |+
+  query Query($projectName: String!, $envName: String!, $name: String!) {
+    core_resyncImagePullSecret(projectName: $projectName, envName: $envName, name: $name)
+  }
+variables:
+  projectName: "demo-project"
+  envName: "public-environment"
+  name: "test-ips"
+---
+
+query: |+
+  mutation Core_deleteImagePullSecret($projectName: String!, $envName: String!, $secretName: String!) {
+    core_deleteImagePullSecret(projectName: $projectName, envName: $envName, secretName: $secretName)
+  }
+variables:
+  projectName: "demo-project"
+  envName: "public-environment"
+  secretName: "test-ips"
+---

--- a/.tools/nvim/__http__/console/mres.graphql.yml
+++ b/.tools/nvim/__http__/console/mres.graphql.yml
@@ -1,56 +1,80 @@
 ---
 global:
   namespace: kl-core
-  name: s1
+  # name: s1
+  name: test-db
 ---
 
 label: List Managed Resources
-query: |+
-  query Core_listManagedResources($namespace: String!) {
-    core_listManagedResources(namespace: $namespace) {
-      metadata {
-        name
-      }
-      kind
-      spec {
-        inputs
+query: |+ #graphql
+  query Core_listManagedResources($projectName: String!, $envName: String!) {
+    core_listManagedResources(projectName: $projectName, envName: $envName) {
+      edges {
+        node {
+          accountName
+          spec {
+            resourceName
+            resourceTemplate {
+              msvcRef {
+                apiVersion
+                kind
+                name
+                namespace
+              }
+            }
+          }
+          syncStatus {
+            state
+            recordVersion
+          }
+        }
       }
     }
   }
 variables:
-  namespace: "{{.namespace}}"
+  projectName: "{{.projectName}}"
+  envName: "{{.envName}}"
 ---
 
 label: Create Managed Resource
-query: |+
-  mutation Core_createManagedResource($mres: ManagedResourceIn!) {
-    core_createManagedResource(mres: $mres) {
+query: |+ #graphql
+  mutation Core_createManagedResource($projectName: String!, $envName: String!, $mres: ManagedResourceIn!) {
+    core_createManagedResource(projectName: $projectName, envName: $envName, mres: $mres) {
       spec {
-        inputs
-        msvcRef {
-          name
+        resourceName
+        resourceTemplate {
+          apiVersion
           kind
-        }
-        mresKind {
-          kind
+          msvcRef {
+            apiVersion
+            kind
+            name
+            namespace
+          }
+          spec
         }
       }
     }
   }
 variables:
+  projectName: "{{.projectName}}"
+  envName: "{{.envName}}"
   mres:
+    displayName: "Test Managed Resource"
     metadata:
-      name: '{{.name}}'
-      namespace: '{{.namespace}}'
+      name: "{{.name}}"
     spec:
-      inputs:
-        k1: v1
-      msvcRef:
-        apiVersion: "asdfasdf"
-        kind: StandaloneDatabase
-        name: s1
-      mresKind:
+      resourceTemplate:
+        apiVersion: mongodb.msvc.kloudlite.io/v1
         kind: Database
+        msvcRef:
+          apiVersion: mongodb.msvc.kloudlite.io/v1
+          kind: StandaloneService
+          name: mongodb
+          namespace: pmsvc-mongodb
+        spec:
+          resourceName: "sample"
+
 ---
 
 label: Get ManagedService
@@ -105,4 +129,44 @@ query: |+
 variables:
   namespace: '{{.namespace}}'
   name: "{{.name}}"
+
+---
+
+label: Get Managed Resource Output Keys
+query: |+ #graphql
+  query Query($projectName: String!, $envName: String!, $name: String!) {
+    core_getManagedResouceOutputKeys(projectName: $projectName, envName: $envName, name: $name)
+  }
+variables:
+  # projectName: "{{.projectName}}"
+  # envName: "{{.envName}}"
+  # envName: "public-environment"
+  projectName: "demo-project"
+  envName: "private-environment"
+  # name: "{{.name}}"
+  name: "test-sample-db"
+
+---
+
+label: Get Managed Resource Output Key Values
+query: |+ #graphql
+  query Core_getManagedResouceOutputKeyValues($projectName: String!, $envName: String!, $keyrefs: [ManagedResourceKeyRefIn]) {
+    core_getManagedResouceOutputKeyValues(projectName: $projectName, envName: $envName, keyrefs: $keyrefs) {
+      key
+      mresName
+      value
+    }
+  }
+variables:
+  # projectName: "{{.projectName}}"
+  # envName: "{{.envName}}"
+  projectName: "demo-project"
+  # envName: "public-environment"
+  projectName: "demo-project"
+  envName: "private-environment"
+  keyrefs:
+    - key: URI
+      # mresName: "{{.name}}"
+      mresName: "test-sample-db"
+
 ---

--- a/.tools/nvim/__http__/infra/vpn-devices.graphql.yml
+++ b/.tools/nvim/__http__/infra/vpn-devices.graphql.yml
@@ -42,6 +42,17 @@ variables:
 
 ---
 
+query: |+
+  query Core_listVPNDevicesForUser {
+    core_listVPNDevicesForUser {
+      metadata {
+        name
+      }
+    }
+  }
+
+---
+
 label: Create VPN Device
 query: |+
   mutation Core_createVPNDevice($clusterName: String!, $vpnDevice: VPNDeviceIn!) {

--- a/apps/console/internal/app/adapter-resource-update-publish.go
+++ b/apps/console/internal/app/adapter-resource-update-publish.go
@@ -14,6 +14,24 @@ type ResourceEventPublisherImpl struct {
 	logger logging.Logger
 }
 
+// PublishImagePullSecretEvent implements domain.ResourceEventPublisher.
+func (r *ResourceEventPublisherImpl) PublishImagePullSecretEvent(ips *entities.ImagePullSecret, msg domain.PublishMsg) {
+	subject := fmt.Sprintf("res-updates.account.%s.project.%s.imagepullsecret.%s", ips.AccountName, ips.ProjectName, ips.Name)
+	r.publish(subject, msg)
+}
+
+// PublishConfigEvent implements domain.ResourceEventPublisher.
+func (r *ResourceEventPublisherImpl) PublishConfigEvent(config *entities.Config, msg domain.PublishMsg) {
+	subject := fmt.Sprintf("res-updates.account.%s.project.%s.config.%s", config.AccountName, config.ProjectName, config.Name)
+	r.publish(subject, msg)
+}
+
+// PublishSecretEvent implements domain.ResourceEventPublisher.
+func (r *ResourceEventPublisherImpl) PublishSecretEvent(secret *entities.Secret, msg domain.PublishMsg) {
+	subject := fmt.Sprintf("res-updates.account.%s.project.%s.secret.%s", secret.AccountName, secret.ProjectName, secret.Name)
+	r.publish(subject, msg)
+}
+
 func (r *ResourceEventPublisherImpl) publish(subject string, msg domain.PublishMsg) {
 	if err := r.cli.Conn.Publish(subject, []byte(msg)); err != nil {
 		r.logger.Errorf(err, "failed to publish message to subject %q", subject)
@@ -52,7 +70,7 @@ func (r *ResourceEventPublisherImpl) PublishRouterEvent(router *entities.Router,
 	r.publish(subject, msg)
 }
 
-func (r *ResourceEventPublisherImpl) PublishWorkspaceEvent(env *entities.Environment, msg domain.PublishMsg) {
+func (r *ResourceEventPublisherImpl) PublishEnvironmentEvent(env *entities.Environment, msg domain.PublishMsg) {
 	subject := fmt.Sprintf("res-updates.account.%s.project.%s.environment.%s", env.AccountName, env.ProjectName, env.Name)
 	r.publish(subject, msg)
 }

--- a/apps/console/internal/app/graph/generated/generated.go
+++ b/apps/console/internal/app/graph/generated/generated.go
@@ -47273,7 +47273,7 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 	return res
 }
 
-func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (interface{}, error) {
+func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (any, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -47281,7 +47281,7 @@ func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v inter
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.SelectionSet, v interface{}) graphql.Marshaler {
+func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.SelectionSet, v any) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/apps/console/internal/app/graph/generated/generated.go
+++ b/apps/console/internal/app/graph/generated/generated.go
@@ -369,6 +369,7 @@ type ComplexityRoot struct {
 	}
 
 	Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec struct {
+		ResourceName     func(childComplexity int) int
 		ResourceTemplate func(childComplexity int) int
 	}
 
@@ -2342,6 +2343,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Github__com___kloudlite___operator___apis___crds___v1__Intercept.ToDevice(childComplexity), true
+
+	case "Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec.resourceName":
+		if e.complexity.Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec.ResourceName == nil {
+			break
+		}
+
+		return e.complexity.Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec.ResourceName(childComplexity), true
 
 	case "Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec.resourceTemplate":
 		if e.complexity.Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec.ResourceTemplate == nil {
@@ -5116,14 +5124,14 @@ type Mutation {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/app.graphqls", Input: `type App @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   enabled: Boolean
   environmentName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -5147,8 +5155,10 @@ type AppPaginatedRecords @shareable {
 }
 
 input AppIn {
+  apiVersion: String
   displayName: String!
   enabled: Boolean
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__AppSpecIn!
 }
@@ -5291,6 +5301,7 @@ type Github__com___kloudlite___operator___apis___crds___v1__Intercept @shareable
 }
 
 type Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec @shareable {
+  resourceName: String
   resourceTemplate: Github__com___kloudlite___operator___apis___crds___v1__MresResourceTemplate!
 }
 
@@ -5556,6 +5567,7 @@ input Github__com___kloudlite___operator___apis___crds___v1__InterceptIn {
 }
 
 input Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpecIn {
+  resourceName: String
   resourceTemplate: Github__com___kloudlite___operator___apis___crds___v1__MresResourceTemplateIn!
 }
 
@@ -5564,6 +5576,8 @@ input Github__com___kloudlite___operator___apis___crds___v1__ManagedServiceSpecI
 }
 
 input Github__com___kloudlite___operator___apis___crds___v1__MresResourceTemplateIn {
+  apiVersion: String!
+  kind: String!
   msvcRef: Github__com___kloudlite___operator___apis___crds___v1__MsvcNamedRefIn!
   spec: Map!
 }
@@ -5723,7 +5737,7 @@ enum K8s__io___api___core___v1__TolerationOperator {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/config.graphqls", Input: `type Config @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   binaryData: Map
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
@@ -5732,7 +5746,7 @@ enum K8s__io___api___core___v1__TolerationOperator {
   environmentName: String!
   id: String!
   immutable: Boolean
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -5754,10 +5768,12 @@ type ConfigPaginatedRecords @shareable {
 }
 
 input ConfigIn {
+  apiVersion: String
   binaryData: Map
   data: Map
   displayName: String!
   immutable: Boolean
+  kind: String
   metadata: MetadataIn
 }
 
@@ -5788,13 +5804,13 @@ input ConfigKeyValueRefIn {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/consolevpndevice.graphqls", Input: `type ConsoleVPNDevice @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   environmentName: String
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -5818,8 +5834,10 @@ type ConsoleVPNDevicePaginatedRecords @shareable {
 }
 
 input ConsoleVPNDeviceIn {
+  apiVersion: String
   displayName: String!
   environmentName: String
+  kind: String
   metadata: MetadataIn
   projectName: String
   spec: Github__com___kloudlite___operator___apis___wireguard___v1__DeviceSpecIn
@@ -5859,12 +5877,12 @@ directive @goField(
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/environment.graphqls", Input: `type Environment @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -5888,7 +5906,9 @@ type EnvironmentPaginatedRecords @shareable {
 }
 
 input EnvironmentIn {
+  apiVersion: String
   displayName: String!
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentSpecIn
 }
@@ -5939,14 +5959,14 @@ input ImagePullSecretIn {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/managedresource.graphqls", Input: `type ManagedResource @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   enabled: Boolean
   environmentName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -5970,8 +5990,10 @@ type ManagedResourcePaginatedRecords @shareable {
 }
 
 input ManagedResourceIn {
+  apiVersion: String
   displayName: String!
   enabled: Boolean
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpecIn!
 }
@@ -6035,13 +6057,13 @@ input PortIn {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/project.graphqls", Input: `type Project @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   clusterName: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -6064,8 +6086,10 @@ type ProjectPaginatedRecords @shareable {
 }
 
 input ProjectIn {
+  apiVersion: String
   clusterName: String
   displayName: String!
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__ProjectSpecIn!
 }
@@ -6073,12 +6097,12 @@ input ProjectIn {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/projectmanagedservice.graphqls", Input: `type ProjectManagedService @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -6102,7 +6126,9 @@ type ProjectManagedServicePaginatedRecords @shareable {
 }
 
 input ProjectManagedServiceIn {
+  apiVersion: String
   displayName: String!
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__ProjectManagedServiceSpecIn
 }
@@ -6110,14 +6136,14 @@ input ProjectManagedServiceIn {
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/router.graphqls", Input: `type Router @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   enabled: Boolean
   environmentName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -6141,8 +6167,10 @@ type RouterPaginatedRecords @shareable {
 }
 
 input RouterIn {
+  apiVersion: String
   displayName: String!
   enabled: Boolean
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__RouterSpecIn!
 }
@@ -6155,7 +6183,7 @@ scalar Date
 `, BuiltIn: false},
 	{Name: "../struct-to-graphql/secret.graphqls", Input: `type Secret @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   data: Map
@@ -6163,7 +6191,7 @@ scalar Date
   environmentName: String!
   id: String!
   immutable: Boolean
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -6187,9 +6215,11 @@ type SecretPaginatedRecords @shareable {
 }
 
 input SecretIn {
+  apiVersion: String
   data: Map
   displayName: String!
   immutable: Boolean
+  kind: String
   metadata: MetadataIn
   stringData: Map
   type: K8s__io___api___core___v1__SecretType
@@ -8400,14 +8430,11 @@ func (ec *executionContext) _App_apiVersion(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_App_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8713,14 +8740,11 @@ func (ec *executionContext) _App_kind(ctx context.Context, field graphql.Collect
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_App_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9538,14 +9562,11 @@ func (ec *executionContext) _Config_apiVersion(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Config_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9933,14 +9954,11 @@ func (ec *executionContext) _Config_kind(ctx context.Context, field graphql.Coll
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Config_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -10940,14 +10958,11 @@ func (ec *executionContext) _ConsoleVPNDevice_apiVersion(ctx context.Context, fi
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ConsoleVPNDevice_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -11209,14 +11224,11 @@ func (ec *executionContext) _ConsoleVPNDevice_kind(ctx context.Context, field gr
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ConsoleVPNDevice_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -12249,14 +12261,11 @@ func (ec *executionContext) _Environment_apiVersion(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Environment_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -12477,14 +12486,11 @@ func (ec *executionContext) _Environment_kind(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Environment_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16675,6 +16681,47 @@ func (ec *executionContext) _Github__com___kloudlite___operator___apis___crds___
 func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___crds___v1__Intercept_toDevice(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Github__com___kloudlite___operator___apis___crds___v1__Intercept",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceName(ctx context.Context, field graphql.CollectedField, obj *model.GithubComKloudliteOperatorApisCrdsV1ManagedResourceSpec) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ResourceName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -20959,14 +21006,11 @@ func (ec *executionContext) _ManagedResource_apiVersion(ctx context.Context, fie
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ManagedResource_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21272,14 +21316,11 @@ func (ec *executionContext) _ManagedResource_kind(ctx context.Context, field gra
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ManagedResource_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21572,6 +21613,8 @@ func (ec *executionContext) fieldContext_ManagedResource_spec(ctx context.Contex
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "resourceName":
+				return ec.fieldContext_Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceName(ctx, field)
 			case "resourceTemplate":
 				return ec.fieldContext_Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceTemplate(ctx, field)
 			}
@@ -26351,14 +26394,11 @@ func (ec *executionContext) _Project_apiVersion(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Project_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -26620,14 +26660,11 @@ func (ec *executionContext) _Project_kind(ctx context.Context, field graphql.Col
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Project_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -27229,14 +27266,11 @@ func (ec *executionContext) _ProjectManagedService_apiVersion(ctx context.Contex
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ProjectManagedService_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -27457,14 +27491,11 @@ func (ec *executionContext) _ProjectManagedService_kind(ctx context.Context, fie
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ProjectManagedService_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -31851,14 +31882,11 @@ func (ec *executionContext) _Router_apiVersion(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Router_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -32164,14 +32192,11 @@ func (ec *executionContext) _Router_kind(ctx context.Context, field graphql.Coll
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Router_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -32985,14 +33010,11 @@ func (ec *executionContext) _Secret_apiVersion(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Secret_apiVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -33339,14 +33361,11 @@ func (ec *executionContext) _Secret_kind(ctx context.Context, field graphql.Coll
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Secret_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -36101,13 +36120,21 @@ func (ec *executionContext) unmarshalInputAppIn(ctx context.Context, obj interfa
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "enabled", "metadata", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "displayName", "enabled", "kind", "metadata", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "displayName":
 			var err error
 
@@ -36121,6 +36148,14 @@ func (ec *executionContext) unmarshalInputAppIn(ctx context.Context, obj interfa
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
 			it.Enabled, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -36159,13 +36194,21 @@ func (ec *executionContext) unmarshalInputConfigIn(ctx context.Context, obj inte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"binaryData", "data", "displayName", "immutable", "metadata"}
+	fieldsInOrder := [...]string{"apiVersion", "binaryData", "data", "displayName", "immutable", "kind", "metadata"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "binaryData":
 			var err error
 
@@ -36201,6 +36244,14 @@ func (ec *executionContext) unmarshalInputConfigIn(ctx context.Context, obj inte
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("immutable"))
 			it.Immutable, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -36308,13 +36359,21 @@ func (ec *executionContext) unmarshalInputConsoleVPNDeviceIn(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "environmentName", "metadata", "projectName", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "displayName", "environmentName", "kind", "metadata", "projectName", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "displayName":
 			var err error
 
@@ -36328,6 +36387,14 @@ func (ec *executionContext) unmarshalInputConsoleVPNDeviceIn(ctx context.Context
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentName"))
 			it.EnvironmentName, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -36493,18 +36560,34 @@ func (ec *executionContext) unmarshalInputEnvironmentIn(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "metadata", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "displayName", "kind", "metadata", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "displayName":
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
 			it.DisplayName, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -37391,13 +37474,21 @@ func (ec *executionContext) unmarshalInputGithub__com___kloudlite___operator___a
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"resourceTemplate"}
+	fieldsInOrder := [...]string{"resourceName", "resourceTemplate"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "resourceName":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("resourceName"))
+			it.ResourceName, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "resourceTemplate":
 			var err error
 
@@ -37447,13 +37538,29 @@ func (ec *executionContext) unmarshalInputGithub__com___kloudlite___operator___a
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"msvcRef", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "kind", "msvcRef", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "msvcRef":
 			var err error
 
@@ -38253,13 +38360,21 @@ func (ec *executionContext) unmarshalInputManagedResourceIn(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "enabled", "metadata", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "displayName", "enabled", "kind", "metadata", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "displayName":
 			var err error
 
@@ -38273,6 +38388,14 @@ func (ec *executionContext) unmarshalInputManagedResourceIn(ctx context.Context,
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
 			it.Enabled, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -38537,13 +38660,21 @@ func (ec *executionContext) unmarshalInputProjectIn(ctx context.Context, obj int
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clusterName", "displayName", "metadata", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "clusterName", "displayName", "kind", "metadata", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "clusterName":
 			var err error
 
@@ -38557,6 +38688,14 @@ func (ec *executionContext) unmarshalInputProjectIn(ctx context.Context, obj int
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
 			it.DisplayName, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -38595,18 +38734,34 @@ func (ec *executionContext) unmarshalInputProjectManagedServiceIn(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "metadata", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "displayName", "kind", "metadata", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "displayName":
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
 			it.DisplayName, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -38645,13 +38800,21 @@ func (ec *executionContext) unmarshalInputRouterIn(ctx context.Context, obj inte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "enabled", "metadata", "spec"}
+	fieldsInOrder := [...]string{"apiVersion", "displayName", "enabled", "kind", "metadata", "spec"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "displayName":
 			var err error
 
@@ -38665,6 +38828,14 @@ func (ec *executionContext) unmarshalInputRouterIn(ctx context.Context, obj inte
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
 			it.Enabled, err = ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -39123,13 +39294,21 @@ func (ec *executionContext) unmarshalInputSecretIn(ctx context.Context, obj inte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"data", "displayName", "immutable", "metadata", "stringData", "type"}
+	fieldsInOrder := [...]string{"apiVersion", "data", "displayName", "immutable", "kind", "metadata", "stringData", "type"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "apiVersion":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("apiVersion"))
+			it.APIVersion, err = ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "data":
 			var err error
 
@@ -39154,6 +39333,14 @@ func (ec *executionContext) unmarshalInputSecretIn(ctx context.Context, obj inte
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("immutable"))
 			it.Immutable, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "kind":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("kind"))
+			it.Kind, err = ec.unmarshalOString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -39305,9 +39492,6 @@ func (ec *executionContext) _App(ctx context.Context, sel ast.SelectionSet, obj 
 
 			out.Values[i] = ec._App_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._App_createdBy(ctx, field, obj)
@@ -39377,9 +39561,6 @@ func (ec *executionContext) _App(ctx context.Context, sel ast.SelectionSet, obj 
 
 			out.Values[i] = ec._App_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._App_lastUpdatedBy(ctx, field, obj)
@@ -39569,9 +39750,6 @@ func (ec *executionContext) _Config(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Values[i] = ec._Config_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "binaryData":
 			field := field
 
@@ -39675,9 +39853,6 @@ func (ec *executionContext) _Config(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Values[i] = ec._Config_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._Config_lastUpdatedBy(ctx, field, obj)
@@ -39952,9 +40127,6 @@ func (ec *executionContext) _ConsoleVPNDevice(ctx context.Context, sel ast.Selec
 
 			out.Values[i] = ec._ConsoleVPNDevice_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._ConsoleVPNDevice_createdBy(ctx, field, obj)
@@ -40017,9 +40189,6 @@ func (ec *executionContext) _ConsoleVPNDevice(ctx context.Context, sel ast.Selec
 
 			out.Values[i] = ec._ConsoleVPNDevice_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._ConsoleVPNDevice_lastUpdatedBy(ctx, field, obj)
@@ -40258,9 +40427,6 @@ func (ec *executionContext) _Environment(ctx context.Context, sel ast.SelectionS
 
 			out.Values[i] = ec._Environment_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._Environment_createdBy(ctx, field, obj)
@@ -40319,9 +40485,6 @@ func (ec *executionContext) _Environment(ctx context.Context, sel ast.SelectionS
 
 			out.Values[i] = ec._Environment_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._Environment_lastUpdatedBy(ctx, field, obj)
@@ -41329,6 +41492,10 @@ func (ec *executionContext) _Github__com___kloudlite___operator___apis___crds___
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec")
+		case "resourceName":
+
+			out.Values[i] = ec._Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceName(ctx, field, obj)
+
 		case "resourceTemplate":
 
 			out.Values[i] = ec._Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec_resourceTemplate(ctx, field, obj)
@@ -42459,9 +42626,6 @@ func (ec *executionContext) _ManagedResource(ctx context.Context, sel ast.Select
 
 			out.Values[i] = ec._ManagedResource_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._ManagedResource_createdBy(ctx, field, obj)
@@ -42531,9 +42695,6 @@ func (ec *executionContext) _ManagedResource(ctx context.Context, sel ast.Select
 
 			out.Values[i] = ec._ManagedResource_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._ManagedResource_lastUpdatedBy(ctx, field, obj)
@@ -43283,9 +43444,6 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Project_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "clusterName":
 
 			out.Values[i] = ec._Project_clusterName(ctx, field, obj)
@@ -43348,9 +43506,6 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Project_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._Project_lastUpdatedBy(ctx, field, obj)
@@ -43491,9 +43646,6 @@ func (ec *executionContext) _ProjectManagedService(ctx context.Context, sel ast.
 
 			out.Values[i] = ec._ProjectManagedService_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._ProjectManagedService_createdBy(ctx, field, obj)
@@ -43552,9 +43704,6 @@ func (ec *executionContext) _ProjectManagedService(ctx context.Context, sel ast.
 
 			out.Values[i] = ec._ProjectManagedService_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._ProjectManagedService_lastUpdatedBy(ctx, field, obj)
@@ -44584,9 +44733,6 @@ func (ec *executionContext) _Router(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Values[i] = ec._Router_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._Router_createdBy(ctx, field, obj)
@@ -44656,9 +44802,6 @@ func (ec *executionContext) _Router(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Values[i] = ec._Router_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._Router_lastUpdatedBy(ctx, field, obj)
@@ -44848,9 +44991,6 @@ func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Values[i] = ec._Secret_apiVersion(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._Secret_createdBy(ctx, field, obj)
@@ -44937,9 +45077,6 @@ func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Values[i] = ec._Secret_kind(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "lastUpdatedBy":
 
 			out.Values[i] = ec._Secret_lastUpdatedBy(ctx, field, obj)
@@ -47273,7 +47410,7 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 	return res
 }
 
-func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (any, error) {
+func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (interface{}, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -47281,7 +47418,7 @@ func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v inter
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.SelectionSet, v any) graphql.Marshaler {
+func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.SelectionSet, v interface{}) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/apps/console/internal/app/graph/generated/generated.go
+++ b/apps/console/internal/app/graph/generated/generated.go
@@ -178,7 +178,6 @@ type ComplexityRoot struct {
 		RecordVersion     func(childComplexity int) int
 		Spec              func(childComplexity int) int
 		Status            func(childComplexity int) int
-		SyncStatus        func(childComplexity int) int
 		UpdateTime        func(childComplexity int) int
 		WireguardConfig   func(childComplexity int) int
 	}
@@ -704,7 +703,7 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		CoreCheckNameAvailability            func(childComplexity int, projectName string, envName *string, resType entities.ResourceType, name string) int
+		CoreCheckNameAvailability            func(childComplexity int, projectName *string, envName *string, resType entities.ResourceType, name string) int
 		CoreGetApp                           func(childComplexity int, projectName string, envName string, name string) int
 		CoreGetConfig                        func(childComplexity int, projectName string, envName string, name string) int
 		CoreGetConfigValues                  func(childComplexity int, projectName string, envName string, queries []*domain.ConfigKeyRef) int
@@ -954,7 +953,7 @@ type ProjectManagedServiceResolver interface {
 	UpdateTime(ctx context.Context, obj *entities.ProjectManagedService) (string, error)
 }
 type QueryResolver interface {
-	CoreCheckNameAvailability(ctx context.Context, projectName string, envName *string, resType entities.ResourceType, name string) (*domain.CheckNameAvailabilityOutput, error)
+	CoreCheckNameAvailability(ctx context.Context, projectName *string, envName *string, resType entities.ResourceType, name string) (*domain.CheckNameAvailabilityOutput, error)
 	CoreListProjects(ctx context.Context, search *model.SearchProjects, pq *repos.CursorPagination) (*model.ProjectPaginatedRecords, error)
 	CoreGetProject(ctx context.Context, name string) (*entities.Project, error)
 	CoreResyncProject(ctx context.Context, name string) (bool, error)
@@ -1552,13 +1551,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ConsoleVPNDevice.Status(childComplexity), true
-
-	case "ConsoleVPNDevice.syncStatus":
-		if e.complexity.ConsoleVPNDevice.SyncStatus == nil {
-			break
-		}
-
-		return e.complexity.ConsoleVPNDevice.SyncStatus(childComplexity), true
 
 	case "ConsoleVPNDevice.updateTime":
 		if e.complexity.ConsoleVPNDevice.UpdateTime == nil {
@@ -4024,7 +4016,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.CoreCheckNameAvailability(childComplexity, args["projectName"].(string), args["envName"].(*string), args["resType"].(entities.ResourceType), args["name"].(string)), true
+		return e.complexity.Query.CoreCheckNameAvailability(childComplexity, args["projectName"].(*string), args["envName"].(*string), args["resType"].(entities.ResourceType), args["name"].(string)), true
 
 	case "Query.core_getApp":
 		if e.complexity.Query.CoreGetApp == nil {
@@ -5024,7 +5016,7 @@ input CoreSearchVPNDevices {
 }
 
 type Query {
-    core_checkNameAvailability(projectName: String!, envName: String, resType: ConsoleResType!, name: String!): ConsoleCheckNameAvailabilityOutput! @isLoggedIn @hasAccount
+    core_checkNameAvailability(projectName: String, envName: String, resType: ConsoleResType!, name: String!): ConsoleCheckNameAvailabilityOutput! @isLoggedIn @hasAccount
 
     core_listProjects(search: SearchProjects, pq: CursorPaginationIn): ProjectPaginatedRecords @isLoggedInAndVerified @hasAccount
     core_getProject(name: String!): Project @isLoggedInAndVerified @hasAccount
@@ -5693,7 +5685,6 @@ enum Github__com___kloudlite___api___pkg___types__SyncState {
   ERRORED_AT_AGENT
   IDLE
   IN_QUEUE
-  RECEIVED_UPDATE_FROM_AGENT
   UPDATED_AT_AGENT
 }
 
@@ -5811,7 +5802,6 @@ input ConfigKeyValueRefIn {
   recordVersion: Int!
   spec: Github__com___kloudlite___operator___apis___wireguard___v1__DeviceSpec
   status: Github__com___kloudlite___operator___pkg___operator__Status
-  syncStatus: Github__com___kloudlite___api___pkg___types__SyncStatus!
   updateTime: Date!
   wireguardConfig: Github__com___kloudlite___api___pkg___types__EncodedString
 }
@@ -7233,10 +7223,10 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 func (ec *executionContext) field_Query_core_checkNameAvailability_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 string
+	var arg0 *string
 	if tmp, ok := rawArgs["projectName"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectName"))
-		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -11585,64 +11575,6 @@ func (ec *executionContext) fieldContext_ConsoleVPNDevice_status(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _ConsoleVPNDevice_syncStatus(ctx context.Context, field graphql.CollectedField, obj *entities.ConsoleVPNDevice) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ConsoleVPNDevice_syncStatus(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.SyncStatus, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(types.SyncStatus)
-	fc.Result = res
-	return ec.marshalNGithub__com___kloudlite___api___pkg___types__SyncStatus2githubᚗcomᚋkloudliteᚋapiᚋpkgᚋtypesᚐSyncStatus(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ConsoleVPNDevice_syncStatus(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ConsoleVPNDevice",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "action":
-				return ec.fieldContext_Github__com___kloudlite___api___pkg___types__SyncStatus_action(ctx, field)
-			case "error":
-				return ec.fieldContext_Github__com___kloudlite___api___pkg___types__SyncStatus_error(ctx, field)
-			case "lastSyncedAt":
-				return ec.fieldContext_Github__com___kloudlite___api___pkg___types__SyncStatus_lastSyncedAt(ctx, field)
-			case "recordVersion":
-				return ec.fieldContext_Github__com___kloudlite___api___pkg___types__SyncStatus_recordVersion(ctx, field)
-			case "state":
-				return ec.fieldContext_Github__com___kloudlite___api___pkg___types__SyncStatus_state(ctx, field)
-			case "syncScheduledAt":
-				return ec.fieldContext_Github__com___kloudlite___api___pkg___types__SyncStatus_syncScheduledAt(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Github__com___kloudlite___api___pkg___types__SyncStatus", field.Name)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _ConsoleVPNDevice_updateTime(ctx context.Context, field graphql.CollectedField, obj *entities.ConsoleVPNDevice) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ConsoleVPNDevice_updateTime(ctx, field)
 	if err != nil {
@@ -11847,8 +11779,6 @@ func (ec *executionContext) fieldContext_ConsoleVPNDeviceEdge_node(ctx context.C
 				return ec.fieldContext_ConsoleVPNDevice_spec(ctx, field)
 			case "status":
 				return ec.fieldContext_ConsoleVPNDevice_status(ctx, field)
-			case "syncStatus":
-				return ec.fieldContext_ConsoleVPNDevice_syncStatus(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_ConsoleVPNDevice_updateTime(ctx, field)
 			case "wireguardConfig":
@@ -25731,8 +25661,6 @@ func (ec *executionContext) fieldContext_Mutation_core_createVPNDevice(ctx conte
 				return ec.fieldContext_ConsoleVPNDevice_spec(ctx, field)
 			case "status":
 				return ec.fieldContext_ConsoleVPNDevice_status(ctx, field)
-			case "syncStatus":
-				return ec.fieldContext_ConsoleVPNDevice_syncStatus(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_ConsoleVPNDevice_updateTime(ctx, field)
 			case "wireguardConfig":
@@ -25847,8 +25775,6 @@ func (ec *executionContext) fieldContext_Mutation_core_updateVPNDevice(ctx conte
 				return ec.fieldContext_ConsoleVPNDevice_spec(ctx, field)
 			case "status":
 				return ec.fieldContext_ConsoleVPNDevice_status(ctx, field)
-			case "syncStatus":
-				return ec.fieldContext_ConsoleVPNDevice_syncStatus(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_ConsoleVPNDevice_updateTime(ctx, field)
 			case "wireguardConfig":
@@ -28429,7 +28355,7 @@ func (ec *executionContext) _Query_core_checkNameAvailability(ctx context.Contex
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().CoreCheckNameAvailability(rctx, fc.Args["projectName"].(string), fc.Args["envName"].(*string), fc.Args["resType"].(entities.ResourceType), fc.Args["name"].(string))
+			return ec.resolvers.Query().CoreCheckNameAvailability(rctx, fc.Args["projectName"].(*string), fc.Args["envName"].(*string), fc.Args["resType"].(entities.ResourceType), fc.Args["name"].(string))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.IsLoggedIn == nil {
@@ -31558,8 +31484,6 @@ func (ec *executionContext) fieldContext_Query_core_listVPNDevicesForUser(ctx co
 				return ec.fieldContext_ConsoleVPNDevice_spec(ctx, field)
 			case "status":
 				return ec.fieldContext_ConsoleVPNDevice_status(ctx, field)
-			case "syncStatus":
-				return ec.fieldContext_ConsoleVPNDevice_syncStatus(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_ConsoleVPNDevice_updateTime(ctx, field)
 			case "wireguardConfig":
@@ -31663,8 +31587,6 @@ func (ec *executionContext) fieldContext_Query_core_getVPNDevice(ctx context.Con
 				return ec.fieldContext_ConsoleVPNDevice_spec(ctx, field)
 			case "status":
 				return ec.fieldContext_ConsoleVPNDevice_status(ctx, field)
-			case "syncStatus":
-				return ec.fieldContext_ConsoleVPNDevice_syncStatus(ctx, field)
 			case "updateTime":
 				return ec.fieldContext_ConsoleVPNDevice_updateTime(ctx, field)
 			case "wireguardConfig":
@@ -40145,13 +40067,6 @@ func (ec *executionContext) _ConsoleVPNDevice(ctx context.Context, sel ast.Selec
 
 			out.Values[i] = ec._ConsoleVPNDevice_status(ctx, field, obj)
 
-		case "syncStatus":
-
-			out.Values[i] = ec._ConsoleVPNDevice_syncStatus(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "updateTime":
 			field := field
 

--- a/apps/console/internal/app/graph/model/models_gen.go
+++ b/apps/console/internal/app/graph/model/models_gen.go
@@ -309,10 +309,12 @@ type GithubComKloudliteOperatorApisCrdsV1InterceptIn struct {
 }
 
 type GithubComKloudliteOperatorApisCrdsV1ManagedResourceSpec struct {
+	ResourceName     *string                                                   `json:"resourceName,omitempty"`
 	ResourceTemplate *GithubComKloudliteOperatorApisCrdsV1MresResourceTemplate `json:"resourceTemplate"`
 }
 
 type GithubComKloudliteOperatorApisCrdsV1ManagedResourceSpecIn struct {
+	ResourceName     *string                                                     `json:"resourceName,omitempty"`
 	ResourceTemplate *GithubComKloudliteOperatorApisCrdsV1MresResourceTemplateIn `json:"resourceTemplate"`
 }
 
@@ -332,8 +334,10 @@ type GithubComKloudliteOperatorApisCrdsV1MresResourceTemplate struct {
 }
 
 type GithubComKloudliteOperatorApisCrdsV1MresResourceTemplateIn struct {
-	MsvcRef *GithubComKloudliteOperatorApisCrdsV1MsvcNamedRefIn `json:"msvcRef"`
-	Spec    map[string]interface{}                              `json:"spec"`
+	APIVersion string                                              `json:"apiVersion"`
+	Kind       string                                              `json:"kind"`
+	MsvcRef    *GithubComKloudliteOperatorApisCrdsV1MsvcNamedRefIn `json:"msvcRef"`
+	Spec       map[string]interface{}                              `json:"spec"`
 }
 
 type GithubComKloudliteOperatorApisCrdsV1MsvcNamedRef struct {

--- a/apps/console/internal/app/graph/schema.graphqls
+++ b/apps/console/internal/app/graph/schema.graphqls
@@ -84,7 +84,7 @@ input CoreSearchVPNDevices {
 }
 
 type Query {
-    core_checkNameAvailability(projectName: String!, envName: String, resType: ConsoleResType!, name: String!): ConsoleCheckNameAvailabilityOutput! @isLoggedIn @hasAccount
+    core_checkNameAvailability(projectName: String, envName: String, resType: ConsoleResType!, name: String!): ConsoleCheckNameAvailabilityOutput! @isLoggedIn @hasAccount
 
     core_listProjects(search: SearchProjects, pq: CursorPaginationIn): ProjectPaginatedRecords @isLoggedInAndVerified @hasAccount
     core_getProject(name: String!): Project @isLoggedInAndVerified @hasAccount

--- a/apps/console/internal/app/graph/schema.resolvers.go
+++ b/apps/console/internal/app/graph/schema.resolvers.go
@@ -7,7 +7,6 @@ package graph
 import (
 	"context"
 	"fmt"
-
 	"github.com/kloudlite/api/pkg/errors"
 
 	"github.com/kloudlite/api/apps/console/internal/app/graph/generated"
@@ -368,7 +367,7 @@ func (r *mutationResolver) CoreDeleteVPNDevice(ctx context.Context, deviceName s
 }
 
 // CoreCheckNameAvailability is the resolver for the core_checkNameAvailability field.
-func (r *queryResolver) CoreCheckNameAvailability(ctx context.Context, projectName string, envName *string, resType entities.ResourceType, name string) (*domain.CheckNameAvailabilityOutput, error) {
+func (r *queryResolver) CoreCheckNameAvailability(ctx context.Context, projectName *string, envName *string, resType entities.ResourceType, name string) (*domain.CheckNameAvailabilityOutput, error) {
 	cc, err := toConsoleContext(ctx)
 	if err != nil {
 		return nil, err
@@ -934,7 +933,5 @@ func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResol
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
-type (
-	mutationResolver struct{ *Resolver }
-	queryResolver    struct{ *Resolver }
-)
+type mutationResolver struct{ *Resolver }
+type queryResolver struct{ *Resolver }

--- a/apps/console/internal/app/graph/struct-to-graphql/app.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/app.graphqls
@@ -1,13 +1,13 @@
 type App @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   enabled: Boolean
   environmentName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -31,8 +31,10 @@ type AppPaginatedRecords @shareable {
 }
 
 input AppIn {
+  apiVersion: String
   displayName: String!
   enabled: Boolean
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__AppSpecIn!
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/common-types.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/common-types.graphqls
@@ -529,7 +529,6 @@ enum Github__com___kloudlite___api___pkg___types__SyncState {
   ERRORED_AT_AGENT
   IDLE
   IN_QUEUE
-  RECEIVED_UPDATE_FROM_AGENT
   UPDATED_AT_AGENT
 }
 

--- a/apps/console/internal/app/graph/struct-to-graphql/common-types.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/common-types.graphqls
@@ -135,6 +135,7 @@ type Github__com___kloudlite___operator___apis___crds___v1__Intercept @shareable
 }
 
 type Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpec @shareable {
+  resourceName: String
   resourceTemplate: Github__com___kloudlite___operator___apis___crds___v1__MresResourceTemplate!
 }
 
@@ -400,6 +401,7 @@ input Github__com___kloudlite___operator___apis___crds___v1__InterceptIn {
 }
 
 input Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpecIn {
+  resourceName: String
   resourceTemplate: Github__com___kloudlite___operator___apis___crds___v1__MresResourceTemplateIn!
 }
 
@@ -408,6 +410,8 @@ input Github__com___kloudlite___operator___apis___crds___v1__ManagedServiceSpecI
 }
 
 input Github__com___kloudlite___operator___apis___crds___v1__MresResourceTemplateIn {
+  apiVersion: String!
+  kind: String!
   msvcRef: Github__com___kloudlite___operator___apis___crds___v1__MsvcNamedRefIn!
   spec: Map!
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/config.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/config.graphqls
@@ -1,6 +1,6 @@
 type Config @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   binaryData: Map
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
@@ -9,7 +9,7 @@ type Config @shareable {
   environmentName: String!
   id: String!
   immutable: Boolean
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -31,10 +31,12 @@ type ConfigPaginatedRecords @shareable {
 }
 
 input ConfigIn {
+  apiVersion: String
   binaryData: Map
   data: Map
   displayName: String!
   immutable: Boolean
+  kind: String
   metadata: MetadataIn
 }
 

--- a/apps/console/internal/app/graph/struct-to-graphql/consolevpndevice.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/consolevpndevice.graphqls
@@ -14,7 +14,6 @@ type ConsoleVPNDevice @shareable {
   recordVersion: Int!
   spec: Github__com___kloudlite___operator___apis___wireguard___v1__DeviceSpec
   status: Github__com___kloudlite___operator___pkg___operator__Status
-  syncStatus: Github__com___kloudlite___api___pkg___types__SyncStatus!
   updateTime: Date!
   wireguardConfig: Github__com___kloudlite___api___pkg___types__EncodedString
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/consolevpndevice.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/consolevpndevice.graphqls
@@ -1,12 +1,12 @@
 type ConsoleVPNDevice @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   environmentName: String
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -30,8 +30,10 @@ type ConsoleVPNDevicePaginatedRecords @shareable {
 }
 
 input ConsoleVPNDeviceIn {
+  apiVersion: String
   displayName: String!
   environmentName: String
+  kind: String
   metadata: MetadataIn
   projectName: String
   spec: Github__com___kloudlite___operator___apis___wireguard___v1__DeviceSpecIn

--- a/apps/console/internal/app/graph/struct-to-graphql/environment.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/environment.graphqls
@@ -1,11 +1,11 @@
 type Environment @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -29,7 +29,9 @@ type EnvironmentPaginatedRecords @shareable {
 }
 
 input EnvironmentIn {
+  apiVersion: String
   displayName: String!
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentSpecIn
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/managedresource.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/managedresource.graphqls
@@ -1,13 +1,13 @@
 type ManagedResource @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   enabled: Boolean
   environmentName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -31,8 +31,10 @@ type ManagedResourcePaginatedRecords @shareable {
 }
 
 input ManagedResourceIn {
+  apiVersion: String
   displayName: String!
   enabled: Boolean
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__ManagedResourceSpecIn!
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/project.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/project.graphqls
@@ -1,12 +1,12 @@
 type Project @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   clusterName: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -29,8 +29,10 @@ type ProjectPaginatedRecords @shareable {
 }
 
 input ProjectIn {
+  apiVersion: String
   clusterName: String
   displayName: String!
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__ProjectSpecIn!
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/projectmanagedservice.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/projectmanagedservice.graphqls
@@ -1,11 +1,11 @@
 type ProjectManagedService @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -29,7 +29,9 @@ type ProjectManagedServicePaginatedRecords @shareable {
 }
 
 input ProjectManagedServiceIn {
+  apiVersion: String
   displayName: String!
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__ProjectManagedServiceSpecIn
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/router.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/router.graphqls
@@ -1,13 +1,13 @@
 type Router @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   displayName: String!
   enabled: Boolean
   environmentName: String!
   id: String!
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -31,8 +31,10 @@ type RouterPaginatedRecords @shareable {
 }
 
 input RouterIn {
+  apiVersion: String
   displayName: String!
   enabled: Boolean
+  kind: String
   metadata: MetadataIn
   spec: Github__com___kloudlite___operator___apis___crds___v1__RouterSpecIn!
 }

--- a/apps/console/internal/app/graph/struct-to-graphql/secret.graphqls
+++ b/apps/console/internal/app/graph/struct-to-graphql/secret.graphqls
@@ -1,6 +1,6 @@
 type Secret @shareable {
   accountName: String!
-  apiVersion: String!
+  apiVersion: String
   createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   creationTime: Date!
   data: Map
@@ -8,7 +8,7 @@ type Secret @shareable {
   environmentName: String!
   id: String!
   immutable: Boolean
-  kind: String!
+  kind: String
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata @goField(name: "objectMeta")
@@ -32,9 +32,11 @@ type SecretPaginatedRecords @shareable {
 }
 
 input SecretIn {
+  apiVersion: String
   data: Map
   displayName: String!
   immutable: Boolean
+  kind: String
   metadata: MetadataIn
   stringData: Map
   type: K8s__io___api___core___v1__SecretType

--- a/apps/console/internal/app/process-resource-updates.go
+++ b/apps/console/internal/app/process-resource-updates.go
@@ -234,6 +234,7 @@ func ProcessResourceUpdates(consumer ResourceUpdateConsumer, d domain.Domain, lo
 				}
 				return d.OnSecretUpdateMessage(rctx, secret, resStatus, opts)
 			}
+
 		case routerGVK.String():
 			{
 				var router entities.Router

--- a/apps/console/internal/app/process-resource-updates.go
+++ b/apps/console/internal/app/process-resource-updates.go
@@ -146,15 +146,18 @@ func ProcessResourceUpdates(consumer ResourceUpdateConsumer, d domain.Domain, lo
 				}
 
 				if v, ok := ru.Object[types.KeyProjectManagedSvcSecret]; ok {
-					if v2, ok := v.(*corev1.Secret); ok {
-						pmsvc.SyncedOutputSecretRef = v2
+					s, err := fn.JsonConvertP[corev1.Secret](v)
+					s.SetManagedFields(nil)
+					if err != nil {
+						return err
 					}
+					pmsvc.SyncedOutputSecretRef = s
 				}
 
 				if resStatus == types.ResourceStatusDeleted {
 					return d.OnProjectManagedServiceDeleteMessage(dctx, mapping.ProjectName, pmsvc)
 				}
-				return d.OnProjectManagedServiceUpdateMessage(dctx, pmsvc.ProjectName, pmsvc, resStatus, opts)
+				return d.OnProjectManagedServiceUpdateMessage(dctx, mapping.ProjectName, pmsvc, resStatus, opts)
 			}
 
 		case environmentGVK.String():

--- a/apps/console/internal/domain/api.go
+++ b/apps/console/internal/domain/api.go
@@ -100,7 +100,7 @@ type UpdateAndDeleteOpts struct {
 }
 
 type Domain interface {
-	CheckNameAvailability(ctx context.Context, accountName string, projectName string, environmentName *string, resType entities.ResourceType, name string) (*CheckNameAvailabilityOutput, error)
+	CheckNameAvailability(ctx context.Context, accountName string, projectName *string, environmentName *string, resType entities.ResourceType, name string) (*CheckNameAvailabilityOutput, error)
 
 	ListProjects(ctx context.Context, userId repos.ID, accountName string, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.Project], error)
 	GetProject(ctx ConsoleContext, name string) (*entities.Project, error)
@@ -213,7 +213,8 @@ type Domain interface {
 
 	ResyncImagePullSecret(ctx ResourceContext, name string) error
 
-	GetResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error)
+	GetEnvironmentResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error)
+	GetProjectResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, name string) (*entities.ResourceMapping, error)
 
 	ListProjectManagedServices(ctx ConsoleContext, projectName string, mf map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.ProjectManagedService], error)
 	GetProjectManagedService(ctx ConsoleContext, projectName string, serviceName string) (*entities.ProjectManagedService, error)
@@ -245,10 +246,13 @@ const (
 
 type ResourceEventPublisher interface {
 	PublishAppEvent(app *entities.App, msg PublishMsg)
+	PublishConfigEvent(config *entities.Config, msg PublishMsg)
+	PublishSecretEvent(secret *entities.Secret, msg PublishMsg)
+	PublishImagePullSecretEvent(ips *entities.ImagePullSecret, msg PublishMsg)
 	PublishMresEvent(mres *entities.ManagedResource, msg PublishMsg)
 	PublishProjectEvent(project *entities.Project, msg PublishMsg)
 	PublishProjectManagedServiceEvent(project *entities.ProjectManagedService, msg PublishMsg)
 	PublishRouterEvent(router *entities.Router, msg PublishMsg)
-	PublishWorkspaceEvent(workspace *entities.Environment, msg PublishMsg)
+	PublishEnvironmentEvent(environment *entities.Environment, msg PublishMsg)
 	PublishVpnDeviceEvent(device *entities.ConsoleVPNDevice, msg PublishMsg)
 }

--- a/apps/console/internal/domain/app.go
+++ b/apps/console/internal/domain/app.go
@@ -187,14 +187,14 @@ func (d *domain) InterceptApp(ctx ResourceContext, appName string, deviceName st
 		return false, err
 	}
 
-	intercepted := app.Spec.Intercept != nil && app.Spec.Intercept.Enabled
+	// intercepted := app.Spec.Intercept != nil && app.Spec.Intercept.Enabled
 
-	if intercepted && app.Spec.Intercept.ToDevice != deviceName {
-		return false, errors.Newf("device (%s) is already intercepting app (%s)", app.Spec.Intercept.ToDevice, appName)
-	}
+	// if intercepted && app.Spec.Intercept.ToDevice != deviceName {
+	// 	return false, errors.Newf("device (%s) is already intercepting app (%s)", app.Spec.Intercept.ToDevice, appName)
+	// }
 
 	patch := repos.Document{
-		"intercept": crdsv1.Intercept{
+		"spec.intercept": crdsv1.Intercept{
 			Enabled:  intercept,
 			ToDevice: deviceName,
 		},
@@ -240,8 +240,8 @@ func (d *domain) OnAppUpdateMessage(ctx ResourceContext, app entities.App, statu
 		"syncStatus.error":         nil,
 	}
 
-	_, err = d.appRepo.PatchById(ctx, xApp.Id, patch)
-	d.resourceEventPublisher.PublishAppEvent(xApp, PublishUpdate)
+	uapp, err := d.appRepo.PatchById(ctx, xApp.Id, patch)
+	d.resourceEventPublisher.PublishAppEvent(uapp, PublishUpdate)
 	return errors.NewE(err)
 }
 

--- a/apps/console/internal/domain/app.go
+++ b/apps/console/internal/domain/app.go
@@ -200,11 +200,12 @@ func (d *domain) InterceptApp(ctx ResourceContext, appName string, deviceName st
 		},
 	}
 
-	if _, err := d.appRepo.PatchById(ctx, app.Id, patch); err != nil {
+	uApp, err := d.appRepo.PatchById(ctx, app.Id, patch)
+	if err != nil {
 		return false, errors.NewE(err)
 	}
 
-	if err := d.applyApp(ctx, app); err != nil {
+	if err := d.applyApp(ctx, uApp); err != nil {
 		return false, errors.NewE(err)
 	}
 

--- a/apps/console/internal/domain/image-pull-secret.go
+++ b/apps/console/internal/domain/image-pull-secret.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (d *domain) ListImagePullSecrets(ctx ResourceContext, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.ImagePullSecret], error) {
-	if err := d.canReadSecretsFromAccount(ctx, string(ctx.UserId), ctx.AccountName); err != nil {
+	if err := d.canReadResourcesInEnvironment(ctx); err != nil {
 		return nil, errors.NewE(err)
 	}
 
@@ -42,7 +42,7 @@ func (d *domain) findImagePullSecret(ctx ResourceContext, name string) (*entitie
 }
 
 func (d *domain) GetImagePullSecret(ctx ResourceContext, name string) (*entities.ImagePullSecret, error) {
-	if err := d.canReadSecretsFromAccount(ctx, string(ctx.UserId), ctx.AccountName); err != nil {
+	if err := d.canReadResourcesInEnvironment(ctx); err != nil {
 		return nil, errors.NewE(err)
 	}
 
@@ -86,14 +86,14 @@ func generateImagePullSecret(ips entities.ImagePullSecret) (corev1.Secret, error
 			},
 		},
 		Data: data,
-		Type: corev1.SecretTypeDockercfg,
+		Type: corev1.SecretTypeDockerConfigJson,
 	}
 
 	return secret, nil
 }
 
 func (d *domain) CreateImagePullSecret(ctx ResourceContext, ips entities.ImagePullSecret) (*entities.ImagePullSecret, error) {
-	if err := d.canMutateSecretsInAccount(ctx, string(ctx.UserId), ctx.AccountName); err != nil {
+	if err := d.canMutateResourcesInEnvironment(ctx); err != nil {
 		return nil, errors.NewE(err)
 	}
 
@@ -149,7 +149,7 @@ func (d *domain) CreateImagePullSecret(ctx ResourceContext, ips entities.ImagePu
 }
 
 func (d *domain) UpdateImagePullSecret(ctx ResourceContext, ips entities.ImagePullSecret) (*entities.ImagePullSecret, error) {
-	if err := d.canMutateSecretsInAccount(ctx, string(ctx.UserId), ctx.AccountName); err != nil {
+	if err := d.canMutateResourcesInEnvironment(ctx); err != nil {
 		return nil, errors.NewE(err)
 	}
 

--- a/apps/console/internal/domain/mres.go
+++ b/apps/console/internal/domain/mres.go
@@ -118,6 +118,10 @@ func (d *domain) CreateManagedResource(ctx ResourceContext, mres entities.Manage
 		return nil, errors.NewE(err)
 	}
 
+	if mres.Spec.ResourceTemplate.TypeMeta.GroupVersionKind().GroupKind().Empty() {
+		return nil, errors.New(".spec.resourceTemplate.apiVersion, and .spec.resourceTemplate.kind must be set")
+	}
+
 	env, err := d.findEnvironment(ctx.ConsoleContext, ctx.ProjectName, ctx.EnvironmentName)
 	if err != nil {
 		return nil, errors.NewE(err)

--- a/apps/console/internal/domain/mres.go
+++ b/apps/console/internal/domain/mres.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kloudlite/api/apps/console/internal/entities"
@@ -146,6 +147,8 @@ func (d *domain) CreateManagedResource(ctx ResourceContext, mres entities.Manage
 	mres.AccountName = ctx.AccountName
 	mres.ProjectName = ctx.ProjectName
 	mres.EnvironmentName = ctx.EnvironmentName
+
+	mres.Spec.ResourceName = fmt.Sprintf("env-%s-%s", ctx.EnvironmentName, mres.Name)
 
 	mres.SyncStatus = t.GenSyncStatus(t.SyncActionApply, mres.RecordVersion)
 

--- a/apps/console/internal/domain/project-managed-service.go
+++ b/apps/console/internal/domain/project-managed-service.go
@@ -252,6 +252,8 @@ func (d *domain) OnProjectManagedServiceUpdateMessage(ctx ConsoleContext, projec
 		"metadata.generation":        service.Generation,
 		"metadata.creationTimestamp": service.CreationTimestamp,
 
+		"syncedOutputSecretRef": service.SyncedOutputSecretRef,
+
 		"status": service.Status,
 		"syncStatus.state": func() t.SyncState {
 			if status == types.ResourceStatusDeleting {

--- a/apps/console/internal/domain/resource-mapping.go
+++ b/apps/console/internal/domain/resource-mapping.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"github.com/kloudlite/api/apps/console/internal/entities"
+	"github.com/kloudlite/api/pkg/errors"
 	"github.com/kloudlite/api/pkg/repos"
 )
 
@@ -11,17 +12,33 @@ type resource interface {
 	GetResourceType() entities.ResourceType
 }
 
-var _ resource = (*entities.App)(nil)
-var _ resource = (*entities.Config)(nil)
-var _ resource = (*entities.Secret)(nil)
-var _ resource = (*entities.Router)(nil)
-var _ resource = (*entities.ManagedResource)(nil)
-var _ resource = (*entities.ImagePullSecret)(nil)
-var _ resource = (*entities.Project)(nil)
-var _ resource = (*entities.Environment)(nil)
+var (
+	_ resource = (*entities.App)(nil)
+	_ resource = (*entities.Config)(nil)
+	_ resource = (*entities.Secret)(nil)
+	_ resource = (*entities.Router)(nil)
+	_ resource = (*entities.ManagedResource)(nil)
+	_ resource = (*entities.ImagePullSecret)(nil)
+	_ resource = (*entities.Project)(nil)
+	_ resource = (*entities.Environment)(nil)
+	_ resource = (*entities.ProjectManagedService)(nil)
+)
 
-func (d *domain) upsertResourceMapping(ctx ResourceContext, res resource) (*entities.ResourceMapping, error) {
+func (d *domain) upsertEnvironmentResourceMapping(ctx ResourceContext, res resource) (*entities.ResourceMapping, error) {
+	clusterName, err := d.getClusterAttachedToProject(ctx, ctx.ProjectName)
+	if err != nil {
+		return nil, errors.NewE(err)
+	}
+	if clusterName == nil {
+		// silent exit
+		return nil, nil
+	}
+
 	return d.resourceMappingRepo.Upsert(ctx, repos.Filter{
+		"resourceHeirarchy": entities.ResourceHeirarchyEnvironment,
+
+		"clusterName": clusterName,
+
 		"resourceType":      res.GetResourceType(),
 		"resourceName":      res.GetName(),
 		"resourceNamespace": res.GetNamespace(),
@@ -30,22 +47,72 @@ func (d *domain) upsertResourceMapping(ctx ResourceContext, res resource) (*enti
 		"projectName":     ctx.ProjectName,
 		"environmentName": ctx.EnvironmentName,
 	}, &entities.ResourceMapping{
+		ResourceHeirarchy: entities.ResourceHeirarchyEnvironment,
+
 		ResourceType:      res.GetResourceType(),
 		ResourceName:      res.GetName(),
 		ResourceNamespace: res.GetNamespace(),
 
-		AccountName:     ctx.AccountName,
+		AccountName: ctx.AccountName,
+		ClusterName: *clusterName,
+
 		ProjectName:     ctx.ProjectName,
 		EnvironmentName: ctx.EnvironmentName,
 	})
 }
 
-func (d *domain) GetResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error) {
+func (d *domain) upsertProjectResourceMapping(ctx ConsoleContext, projectName string, res resource) (*entities.ResourceMapping, error) {
+	clusterName, err := d.getClusterAttachedToProject(ctx, projectName)
+	if err != nil {
+		return nil, errors.NewE(err)
+	}
+	if clusterName == nil {
+		// silent exit
+		return nil, nil
+	}
+
+	return d.resourceMappingRepo.Upsert(ctx, repos.Filter{
+		"resourceHeirarchy": entities.ResourceHeirarchyProject,
+
+		"resourceType":      res.GetResourceType(),
+		"resourceName":      res.GetName(),
+		"resourceNamespace": res.GetNamespace(),
+
+		"accountName": ctx.AccountName,
+		"clusterName": *clusterName,
+
+		"projectName": projectName,
+	}, &entities.ResourceMapping{
+		ResourceHeirarchy: entities.ResourceHeirarchyProject,
+
+		ResourceType:      res.GetResourceType(),
+		ResourceName:      res.GetName(),
+		ResourceNamespace: res.GetNamespace(),
+
+		AccountName: ctx.AccountName,
+		ClusterName: *clusterName,
+
+		ProjectName: projectName,
+	})
+}
+
+func (d *domain) GetEnvironmentResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error) {
 	return d.resourceMappingRepo.FindOne(ctx, repos.Filter{
+		"resourceHeirarchy": entities.ResourceHeirarchyEnvironment,
 		"accountName":       ctx.AccountName,
 		"resourceType":      resType,
 		"resourceName":      name,
 		"clusterName":       clusterName,
 		"resourceNamespace": namespace,
+	})
+}
+
+func (d *domain) GetProjectResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, name string) (*entities.ResourceMapping, error) {
+	return d.resourceMappingRepo.FindOne(ctx, repos.Filter{
+		"resourceHeirarchy": entities.ResourceHeirarchyProject,
+		"accountName":       ctx.AccountName,
+		"clusterName":       clusterName,
+		"resourceType":      resType,
+		"resourceName":      name,
 	})
 }

--- a/apps/console/internal/domain/router.go
+++ b/apps/console/internal/domain/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kloudlite/api/pkg/errors"
 	"github.com/kloudlite/api/pkg/repos"
 	t "github.com/kloudlite/api/pkg/types"
+	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
 	"github.com/kloudlite/operator/operators/resource-watcher/types"
 )
 
@@ -73,6 +74,11 @@ func (d *domain) CreateRouter(ctx ResourceContext, router entities.Router) (*ent
 	router.EnvironmentName = ctx.EnvironmentName
 	router.SyncStatus = t.GenSyncStatus(t.SyncActionApply, router.RecordVersion)
 
+	router.Spec.Https = &crdsv1.Https{
+		Enabled:       true,
+		ForceRedirect: true,
+	}
+
 	if _, err := d.upsertEnvironmentResourceMapping(ctx, &router); err != nil {
 		return nil, errors.NewE(err)
 	}
@@ -108,6 +114,13 @@ func (d *domain) UpdateRouter(ctx ResourceContext, router entities.Router) (*ent
 	router.Namespace = xRouter.Namespace
 	if err := d.k8sClient.ValidateObject(ctx, &router.Router); err != nil {
 		return nil, errors.NewE(err)
+	}
+
+	if router.Spec.Https == nil {
+		router.Spec.Https = &crdsv1.Https{
+			Enabled:       true,
+			ForceRedirect: true,
+		}
 	}
 
 	patch := repos.Document{

--- a/apps/console/internal/domain/vpn-device.go
+++ b/apps/console/internal/domain/vpn-device.go
@@ -157,9 +157,9 @@ func (d *domain) upsertInfraDevice(ctx ConsoleContext, device *entities.ConsoleV
 
 	return d.infraClient.UpsertVpnDevice(ctx, &infra.UpsertVpnDeviceIn{
 		Id:          string(device.Id),
+		VpnDevice:   deviceBytes,
 		AccountName: ctx.AccountName,
 		ClusterName: clusterName,
-		VpnDevice:   deviceBytes,
 	})
 }
 
@@ -184,7 +184,7 @@ func (d *domain) UpdateVPNDevice(ctx ConsoleContext, device entities.ConsoleVPND
 		return nil, errors.NewE(err)
 	}
 
-	_, err := d.findVPNDevice(ctx, device.Name)
+	xdevice, err := d.findVPNDevice(ctx, device.Name)
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
@@ -201,7 +201,7 @@ func (d *domain) UpdateVPNDevice(ctx ConsoleContext, device entities.ConsoleVPND
 		},
 	}
 
-	nDevice, err := d.vpnDeviceRepo.PatchById(ctx, device.Id, patch)
+	nDevice, err := d.vpnDeviceRepo.PatchById(ctx, xdevice.Id, patch)
 	if err != nil {
 		return nil, errors.NewE(err)
 	}

--- a/apps/console/internal/entities/image-pull-secret.go
+++ b/apps/console/internal/entities/image-pull-secret.go
@@ -2,6 +2,7 @@ package entities
 
 import (
 	"fmt"
+
 	"github.com/kloudlite/api/common"
 	"github.com/kloudlite/api/pkg/repos"
 	t "github.com/kloudlite/api/pkg/types"
@@ -28,7 +29,6 @@ type ImagePullSecret struct {
 	RegistryURL      *string `json:"registryURL,omitempty"`
 
 	GeneratedK8sSecret corev1.Secret `json:"generatedK8sSecret,omitempty" graphql:"ignore"`
-	//corev1.Secret    `json:",inline"`
 
 	AccountName     string `json:"accountName" graphql:"noinput"`
 	ProjectName     string `json:"projectName" graphql:"noinput"`

--- a/apps/console/internal/entities/project-managed-service.go
+++ b/apps/console/internal/entities/project-managed-service.go
@@ -21,6 +21,11 @@ type ProjectManagedService struct {
 	SyncStatus              t.SyncStatus `json:"syncStatus" graphql:"noinput"`
 }
 
+// GetResourceType implements domain.resource.
+func (*ProjectManagedService) GetResourceType() ResourceType {
+	return ResourceTypeProjectManagedService
+}
+
 var ProjectManagedServiceIndices = []repos.IndexField{
 	{
 		Field: []repos.IndexKey{

--- a/apps/console/internal/entities/resource-mapping.go
+++ b/apps/console/internal/entities/resource-mapping.go
@@ -14,16 +14,28 @@ const (
 	ResourceTypeRouter                ResourceType = "router"
 	ResourceTypeManagedResource       ResourceType = "managed_resource"
 	ResourceTypeProjectManagedService ResourceType = "project_managed_service"
+	ResourceTypeVPNDevice             ResourceType = "vpn_device"
+)
+
+type ResourceHeirarchy string
+
+const (
+	ResourceHeirarchyProject     ResourceHeirarchy = "project"
+	ResourceHeirarchyEnvironment ResourceHeirarchy = "environment"
 )
 
 type ResourceMapping struct {
 	repos.BaseEntity `bson:",inline"`
 
+	ResourceHeirarchy ResourceHeirarchy `json:"resourceHeirarchy"`
+
 	ResourceType      ResourceType `json:"resourceType"`
 	ResourceName      string       `json:"resourceName"`
 	ResourceNamespace string       `json:"resourceNamespace"`
 
-	AccountName     string `json:"accountName"`
+	AccountName string `json:"accountName"`
+	ClusterName string `json:"clusterName"`
+
 	ProjectName     string `json:"projectName"`
 	EnvironmentName string `json:"environmentName"`
 }

--- a/apps/console/internal/entities/vpn-device.go
+++ b/apps/console/internal/entities/vpn-device.go
@@ -9,18 +9,17 @@ import (
 )
 
 type ConsoleVPNDevice struct {
-	repos.BaseEntity `json:",inline" graphql:"noinput"` // db
+	repos.BaseEntity `json:",inline" graphql:"noinput"`
 
-	wireguardV1.Device `json:",inline" graphql:"uri=k8s://devices.wireguard.kloudlite.io"` // db
+	wireguardV1.Device `json:",inline"`
 
-	common.ResourceMetadata `json:",inline"` // db
+	common.ResourceMetadata `json:",inline"`
 
-	AccountName     string  `json:"accountName" graphql:"noinput"` // db
-	ProjectName     *string `json:"projectName,omitempty"` // db
-	EnvironmentName *string `json:"environmentName,omitempty"` // db
+	AccountName     string  `json:"accountName" graphql:"noinput"`
+	ProjectName     *string `json:"projectName,omitempty"`
+	EnvironmentName *string `json:"environmentName,omitempty"`
 
 	WireguardConfig t.EncodedString `json:"wireguardConfig,omitempty" graphql:"noinput"`
-	SyncStatus              t.SyncStatus `json:"syncStatus" graphql:"noinput"`
 }
 
 var VPNDeviceIndexes = []repos.IndexField{

--- a/apps/infra/internal/app/grpc-server.go
+++ b/apps/infra/internal/app/grpc-server.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/kloudlite/api/apps/infra/internal/domain"
 	"github.com/kloudlite/api/apps/infra/internal/entities"
 	"github.com/kloudlite/api/common"
@@ -56,6 +57,7 @@ func (g *grpcServer) UpsertVpnDevice(ctx context.Context, in *infra.UpsertVpnDev
 	if err := json.Unmarshal(in.VpnDevice, &wgDevice); err != nil {
 		return nil, errors.NewE(err)
 	}
+
 	device, err := g.d.UpsertManagedVPNDevice(dctx, in.ClusterName, entities.VPNDevice{
 		Device:           wgDevice,
 		ResourceMetadata: common.ResourceMetadata{},
@@ -64,7 +66,6 @@ func (g *grpcServer) UpsertVpnDevice(ctx context.Context, in *infra.UpsertVpnDev
 		ManagingByDev:    fn.New(repos.ID(in.Id)),
 		SyncStatus:       t.SyncStatus{},
 	}, repos.ID(in.Id))
-
 	if err != nil {
 		return nil, errors.NewE(err)
 	}

--- a/apps/infra/internal/domain/vpn-device-utils.go
+++ b/apps/infra/internal/domain/vpn-device-utils.go
@@ -39,7 +39,8 @@ func (d *domain) updateVPNDevice(ctx InfraContext, clusterName string, deviceIn 
 		"metadata.annotations": deviceIn.Annotations,
 		"displayName":          deviceIn.DisplayName,
 		"recordVersion":        currDevice.RecordVersion + 1,
-		"spec.Ports":           deviceIn.Spec.Ports,
+		"spec.ports":           deviceIn.Spec.Ports,
+		"spec.deviceNamespace": deviceIn.Spec.DeviceNamespace,
 		"lastUpdatedBy": common.CreatedOrUpdatedBy{
 			UserId:    ctx.UserId,
 			UserName:  ctx.UserName,
@@ -58,7 +59,6 @@ func (d *domain) updateVPNDevice(ctx InfraContext, clusterName string, deviceIn 
 		return nil, errors.NewE(err)
 	}
 	return nDevice, nil
-
 }
 
 func (d *domain) findVPNDevice(ctx InfraContext, clusterName string, name string) (*entities.VPNDevice, error) {
@@ -104,9 +104,9 @@ func (d *domain) deleteVPNDevice(ctx InfraContext, clusterName string, name stri
 	}); err != nil {
 		return errors.NewE(err)
 	}
+
 	d.resourceEventPublisher.PublishVpnDeviceEvent(device, PublishUpdate)
 	return d.resDispatcher.DeleteFromTargetCluster(ctx, clusterName, &device.Device)
-
 }
 
 func (d *domain) createVPNDevice(ctx InfraContext, clusterName string, device entities.VPNDevice) (*entities.VPNDevice, error) {

--- a/apps/tenant-agent/main.go
+++ b/apps/tenant-agent/main.go
@@ -96,8 +96,9 @@ func (g *grpcHandler) handleMessage(msg t.AgentMessage) error {
 				ann = make(map[string]string, 2)
 			}
 
-			ann[constants.ObservabilityAccountNameKey] = msg.AccountName
-			ann[constants.ObservabilityClusterNameKey] = msg.ClusterName
+			ann[constants.ObservabilityAccountNameKey] = g.ev.AccountName
+			ann[constants.ObservabilityClusterNameKey] = g.ev.ClusterName
+			obj.SetAnnotations(ann)
 
 			b, err := yaml.Marshal(msg.Object)
 			if err != nil {

--- a/cmd/struct-to-graphql/pkg/parser/depricated.go
+++ b/cmd/struct-to-graphql/pkg/parser/depricated.go
@@ -1,0 +1,149 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	rApi "github.com/kloudlite/operator/pkg/operator"
+	apiExtensionsV1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+)
+
+func (p *parser) NavigateTree(s *Struct, name string, tree *apiExtensionsV1.JSONSchemaProps, depth ...int) error {
+	currDepth := func() int {
+		if len(depth) == 0 {
+			return 1
+		}
+		return depth[0]
+	}()
+
+	m := map[string]bool{}
+	for i := range tree.Required {
+		m[tree.Required[i]] = true
+	}
+
+	typeName := genTypeName(name)
+
+	fields := make([]string, 0, len(tree.Properties))
+	inputFields := make([]string, 0, len(tree.Properties))
+
+	for k, v := range tree.Properties {
+		if currDepth == 1 {
+			if k == "apiVersion" || k == "kind" {
+				// fields = append(fields, genFieldEntry(k, "String", m[k]))
+				fields = append(fields, genFieldEntry(k, "String", true))
+				// inputFields = append(inputFields, genFieldEntry(k, "String", m[k]))
+				inputFields = append(inputFields, genFieldEntry(k, "String", m[k]))
+				continue
+			}
+		}
+
+		if v.Type == "array" {
+			if v.Items.Schema != nil && v.Items.Schema.Type == "object" {
+				fields = append(fields, genFieldEntry(k, fmt.Sprintf("[%s!]", typeName+genTypeName(k)), m[k]))
+				inputFields = append(inputFields, genFieldEntry(k, fmt.Sprintf("[%sIn!]", typeName+genTypeName(k)), m[k]))
+				if err := p.NavigateTree(s, typeName+genTypeName(k), v.Items.Schema, currDepth+1); err != nil {
+					return err
+				}
+				continue
+			}
+
+			fields = append(fields, genFieldEntry(k, fmt.Sprintf("[%s!]", genTypeName(v.Items.Schema.Type)), m[k]))
+			inputFields = append(inputFields, genFieldEntry(k, fmt.Sprintf("[%s!]", genTypeName(v.Items.Schema.Type)), m[k]))
+			continue
+		}
+
+		if v.Type == "object" {
+			if currDepth == 1 {
+				// these types are common across all the types that will be generated
+				if k == "metadata" {
+					fields = append(fields, genFieldEntry(k, "Metadata! @goField(name: \"objectMeta\")", false))
+					// fields = append(fields, genFieldEntry(k, "Metadata!", false))
+					inputFields = append(inputFields, genFieldEntry(k, "MetadataIn!", false))
+
+					metadata := struct {
+						Name              string            `json:"name"`
+						Namespace         string            `json:"namespace,omitempty"`
+						Labels            map[string]string `json:"labels,omitempty"`
+						Annotations       map[string]string `json:"annotations,omitempty"`
+						Generation        int64             `json:"generation" graphql:"noinput"`
+						CreationTimestamp metav1.Time       `json:"creationTimestamp" graphql:"noinput"`
+						DeletionTimestamp *metav1.Time      `json:"deletionTimestamp,omitempty" graphql:"noinput"`
+					}{}
+					if err := p.GenerateGraphQLSchema(commonLabel, "Metadata", reflect.TypeOf(metadata)); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if k == "status" {
+					pkgPath := SanitizePackagePath("github.com/kloudlite/operator/pkg/operator")
+
+					gType := genTypeName(pkgPath + "_" + "Status")
+
+					fields = append(fields, genFieldEntry(k, gType, m[k]))
+
+					p2 := newParser(p.schemaCli)
+					if err := p2.GenerateGraphQLSchema(commonLabel, gType, reflect.TypeOf(rApi.Status{})); err != nil {
+						return err
+					}
+
+					for _, v := range p2.structs {
+						for k, v2 := range v.Types {
+							p.structs[commonLabel].Types[k] = v2
+						}
+						for k, v2 := range v.Enums {
+							p.structs[commonLabel].Enums[k] = v2
+						}
+					}
+
+					continue
+				}
+			}
+
+			if len(v.Properties) == 0 {
+				fields = append(fields, genFieldEntry(k, "Map", m[k]))
+				inputFields = append(inputFields, genFieldEntry(k, "Map", m[k]))
+				continue
+			}
+
+			fields = append(fields, genFieldEntry(k, typeName+genTypeName(k), m[k]))
+			inputFields = append(inputFields, genFieldEntry(k, typeName+genTypeName(k)+"In", m[k]))
+			if err := p.NavigateTree(s, typeName+genTypeName(k), &v, currDepth+1); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if v.Type == "string" {
+			if len(v.Enum) > 0 {
+				fqtn := typeName + genTypeName(k)
+				fields = append(fields, genFieldEntry(k, fqtn, m[k]))
+				inputFields = append(inputFields, genFieldEntry(k, fqtn, m[k]))
+
+				enums := make([]string, len(v.Enum))
+				for i := range v.Enum {
+					vjson, _ := v.Enum[i].MarshalJSON()
+					var v string
+					if err := json.Unmarshal(vjson, &v); err != nil {
+						return nil
+					}
+					enums[i] = v
+				}
+				s.Enums[fqtn] = enums
+				continue
+			}
+		}
+
+		fields = append(fields, genFieldEntry(k, gqlTypeMap(v.Type), m[k]))
+		inputFields = append(inputFields, genFieldEntry(k, gqlTypeMap(v.Type), m[k]))
+	}
+
+	s.Types[typeName] = fields
+	s.Inputs[typeName+"In"] = inputFields
+	return nil
+}
+
+func (p *parser) GenerateFromJsonSchema(s *Struct, name string, schema *apiExtensionsV1.JSONSchemaProps) error {
+	return p.NavigateTree(s, name, schema)
+}

--- a/cmd/struct-to-graphql/pkg/parser/depricated.go
+++ b/cmd/struct-to-graphql/pkg/parser/depricated.go
@@ -70,7 +70,7 @@ func (p *parser) NavigateTree(s *Struct, name string, tree *apiExtensionsV1.JSON
 						CreationTimestamp metav1.Time       `json:"creationTimestamp" graphql:"noinput"`
 						DeletionTimestamp *metav1.Time      `json:"deletionTimestamp,omitempty" graphql:"noinput"`
 					}{}
-					if err := p.GenerateGraphQLSchema(commonLabel, "Metadata", reflect.TypeOf(metadata)); err != nil {
+					if err := p.GenerateGraphQLSchema(commonLabel, "Metadata", reflect.TypeOf(metadata), GraphqlTag{}); err != nil {
 						return err
 					}
 					continue
@@ -84,7 +84,7 @@ func (p *parser) NavigateTree(s *Struct, name string, tree *apiExtensionsV1.JSON
 					fields = append(fields, genFieldEntry(k, gType, m[k]))
 
 					p2 := newParser(p.schemaCli)
-					if err := p2.GenerateGraphQLSchema(commonLabel, gType, reflect.TypeOf(rApi.Status{})); err != nil {
+					if err := p2.GenerateGraphQLSchema(commonLabel, gType, reflect.TypeOf(rApi.Status{}), GraphqlTag{}); err != nil {
 						return err
 					}
 

--- a/cmd/struct-to-graphql/pkg/parser/parser.go
+++ b/cmd/struct-to-graphql/pkg/parser/parser.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	rApi "github.com/kloudlite/operator/pkg/operator"
 	"github.com/sanity-io/litter"
 	apiExtensionsV1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -173,6 +172,7 @@ type GraphqlTag struct {
 	OnlyInput      bool
 	InputOmitEmpty bool
 	DefaultValue   any
+	Required       bool
 }
 
 func parseGraphqlTag(field reflect.StructField) (GraphqlTag, error) {
@@ -220,6 +220,10 @@ func parseGraphqlTag(field reflect.StructField) (GraphqlTag, error) {
 		case "inputomitempty":
 			{
 				gt.InputOmitEmpty = true
+			}
+		case "required":
+			{
+				gt.Required = true
 			}
 
 		case "ignore":
@@ -301,6 +305,10 @@ func (p *parser) GenerateGraphQLSchema(structName string, name string, t reflect
 
 		if gt.Ignore {
 			continue
+		}
+
+		if gt.Required {
+			jt.OmitEmpty = true
 		}
 
 		var fieldType string
@@ -395,144 +403,6 @@ func (p *parser) GenerateGraphQLSchema(structName string, name string, t reflect
 		p.structs[structName].Inputs[name+"In"] = inputFields
 	}
 	return nil
-}
-
-func (p *parser) NavigateTree(s *Struct, name string, tree *apiExtensionsV1.JSONSchemaProps, depth ...int) error {
-	currDepth := func() int {
-		if len(depth) == 0 {
-			return 1
-		}
-		return depth[0]
-	}()
-
-	m := map[string]bool{}
-	for i := range tree.Required {
-		m[tree.Required[i]] = true
-	}
-
-	typeName := genTypeName(name)
-
-	fields := make([]string, 0, len(tree.Properties))
-	inputFields := make([]string, 0, len(tree.Properties))
-
-	for k, v := range tree.Properties {
-		if currDepth == 1 {
-			if k == "apiVersion" || k == "kind" {
-				// fields = append(fields, genFieldEntry(k, "String", m[k]))
-				fields = append(fields, genFieldEntry(k, "String", true))
-				inputFields = append(inputFields, genFieldEntry(k, "String", m[k]))
-				continue
-			}
-		}
-
-		if v.Type == "array" {
-			if v.Items.Schema != nil && v.Items.Schema.Type == "object" {
-				fields = append(fields, genFieldEntry(k, fmt.Sprintf("[%s!]", typeName+genTypeName(k)), m[k]))
-				inputFields = append(inputFields, genFieldEntry(k, fmt.Sprintf("[%sIn!]", typeName+genTypeName(k)), m[k]))
-				if err := p.NavigateTree(s, typeName+genTypeName(k), v.Items.Schema, currDepth+1); err != nil {
-					return err
-				}
-				continue
-			}
-
-			fields = append(fields, genFieldEntry(k, fmt.Sprintf("[%s!]", genTypeName(v.Items.Schema.Type)), m[k]))
-			inputFields = append(inputFields, genFieldEntry(k, fmt.Sprintf("[%s!]", genTypeName(v.Items.Schema.Type)), m[k]))
-			continue
-		}
-
-		if v.Type == "object" {
-			if currDepth == 1 {
-				// these types are common across all the types that will be generated
-				if k == "metadata" {
-					fields = append(fields, genFieldEntry(k, "Metadata! @goField(name: \"objectMeta\")", false))
-					// fields = append(fields, genFieldEntry(k, "Metadata!", false))
-					inputFields = append(inputFields, genFieldEntry(k, "MetadataIn!", false))
-
-					metadata := struct {
-						Name              string            `json:"name"`
-						Namespace         string            `json:"namespace,omitempty"`
-						Labels            map[string]string `json:"labels,omitempty"`
-						Annotations       map[string]string `json:"annotations,omitempty"`
-						Generation        int64             `json:"generation" graphql:"noinput"`
-						CreationTimestamp metav1.Time       `json:"creationTimestamp" graphql:"noinput"`
-						DeletionTimestamp *metav1.Time      `json:"deletionTimestamp,omitempty" graphql:"noinput"`
-					}{}
-					if err := p.GenerateGraphQLSchema(commonLabel, "Metadata", reflect.TypeOf(metadata)); err != nil {
-						return err
-					}
-					continue
-				}
-
-				if k == "status" {
-					pkgPath := SanitizePackagePath("github.com/kloudlite/operator/pkg/operator")
-
-					gType := genTypeName(pkgPath + "_" + "Status")
-
-					fields = append(fields, genFieldEntry(k, gType, m[k]))
-
-					p2 := newParser(p.schemaCli)
-					if err := p2.GenerateGraphQLSchema(commonLabel, gType, reflect.TypeOf(rApi.Status{})); err != nil {
-						return err
-					}
-
-					for _, v := range p2.structs {
-						for k, v2 := range v.Types {
-							p.structs[commonLabel].Types[k] = v2
-						}
-						for k, v2 := range v.Enums {
-							p.structs[commonLabel].Enums[k] = v2
-						}
-					}
-
-					continue
-				}
-			}
-
-			if len(v.Properties) == 0 {
-				fields = append(fields, genFieldEntry(k, "Map", m[k]))
-				inputFields = append(inputFields, genFieldEntry(k, "Map", m[k]))
-				continue
-			}
-
-			fields = append(fields, genFieldEntry(k, typeName+genTypeName(k), m[k]))
-			inputFields = append(inputFields, genFieldEntry(k, typeName+genTypeName(k)+"In", m[k]))
-			if err := p.NavigateTree(s, typeName+genTypeName(k), &v, currDepth+1); err != nil {
-				return err
-			}
-			continue
-		}
-
-		if v.Type == "string" {
-			if len(v.Enum) > 0 {
-				fqtn := typeName + genTypeName(k)
-				fields = append(fields, genFieldEntry(k, fqtn, m[k]))
-				inputFields = append(inputFields, genFieldEntry(k, fqtn, m[k]))
-
-				enums := make([]string, len(v.Enum))
-				for i := range v.Enum {
-					vjson, _ := v.Enum[i].MarshalJSON()
-					var v string
-					if err := json.Unmarshal(vjson, &v); err != nil {
-						return nil
-					}
-					enums[i] = v
-				}
-				s.Enums[fqtn] = enums
-				continue
-			}
-		}
-
-		fields = append(fields, genFieldEntry(k, gqlTypeMap(v.Type), m[k]))
-		inputFields = append(inputFields, genFieldEntry(k, gqlTypeMap(v.Type), m[k]))
-	}
-
-	s.Types[typeName] = fields
-	s.Inputs[typeName+"In"] = inputFields
-	return nil
-}
-
-func (p *parser) GenerateFromJsonSchema(s *Struct, name string, schema *apiExtensionsV1.JSONSchemaProps) error {
-	return p.NavigateTree(s, name, schema)
 }
 
 func (p *parser) LoadStruct(name string, data any) error {

--- a/cmd/struct-to-graphql/pkg/parser/parser_helpers.go
+++ b/cmd/struct-to-graphql/pkg/parser/parser_helpers.go
@@ -111,21 +111,14 @@ func (f *Field) handleStruct() (fieldType string, inputFieldType string, err err
 	p2.structs[structName] = newStruct()
 
 	if f.Name == "ObjectMeta" && f.PkgPath == "k8s.io/apimachinery/pkg/apis/meta/v1" && f.Type.String() == "v1.ObjectMeta" {
-		if err := p2.GenerateGraphQLSchema(structName, "Metadata", reflect.TypeOf(types.Metadata{})); err != nil {
+		if err := p2.GenerateGraphQLSchema(structName, "Metadata", reflect.TypeOf(types.Metadata{}), f.GraphqlTag); err != nil {
 			return "", "", err
 		}
 		fieldType = types.MetadataToGraphqlFieldEntry(f.OmitEmpty)
 		inputFieldType = types.MetadataToGraphqlInputEntry(f.OmitEmpty)
 	} else {
-		//if f.Name == "TypeMeta" && f.PkgPath == "k8s.io/apimachinery/pkg/apis/meta/v1" && f.Type.String() == "v1.TypeMeta" {
-		//	if err := p2.GenerateGraphQLSchema(structName, childType, reflect.TypeOf(types.TypeMeta{})); err != nil {
-		//		//if err := p2.GenerateGraphQLSchema(structName, childType, reflect.TypeOf(metav1.TypeMeta{})); err != nil {
-		//		return "", "", err
-		//	}
-		//} else {
-		if err := p2.GenerateGraphQLSchema(structName, childType, f.Type); err != nil {
+		if err := p2.GenerateGraphQLSchema(structName, childType, f.Type, f.GraphqlTag); err != nil {
 			return "", "", err
-			//	}
 		}
 
 		if f.Inline {

--- a/cmd/struct-to-graphql/pkg/parser/parser_helpers.go
+++ b/cmd/struct-to-graphql/pkg/parser/parser_helpers.go
@@ -117,15 +117,15 @@ func (f *Field) handleStruct() (fieldType string, inputFieldType string, err err
 		fieldType = types.MetadataToGraphqlFieldEntry(f.OmitEmpty)
 		inputFieldType = types.MetadataToGraphqlInputEntry(f.OmitEmpty)
 	} else {
-
-		if f.Name == "TypeMeta" && f.PkgPath == "k8s.io/apimachinery/pkg/apis/meta/v1" && f.Type.String() == "v1.TypeMeta" {
-			if err := p2.GenerateGraphQLSchema(structName, childType, reflect.TypeOf(types.TypeMeta{})); err != nil {
-				return "", "", err
-			}
-		} else {
-			if err := p2.GenerateGraphQLSchema(structName, childType, f.Type); err != nil {
-				return "", "", err
-			}
+		//if f.Name == "TypeMeta" && f.PkgPath == "k8s.io/apimachinery/pkg/apis/meta/v1" && f.Type.String() == "v1.TypeMeta" {
+		//	if err := p2.GenerateGraphQLSchema(structName, childType, reflect.TypeOf(types.TypeMeta{})); err != nil {
+		//		//if err := p2.GenerateGraphQLSchema(structName, childType, reflect.TypeOf(metav1.TypeMeta{})); err != nil {
+		//		return "", "", err
+		//	}
+		//} else {
+		if err := p2.GenerateGraphQLSchema(structName, childType, f.Type); err != nil {
+			return "", "", err
+			//	}
 		}
 
 		if f.Inline {

--- a/cmd/struct-to-graphql/pkg/parser/parser_test.go
+++ b/cmd/struct-to-graphql/pkg/parser/parser_test.go
@@ -1012,7 +1012,6 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 							"IN_QUEUE",
 							"APPLIED_AT_AGENT",
 							"ERRORED_AT_AGENT",
-							"RECEIVED_UPDATE_FROM_AGENT",
 							"UPDATED_AT_AGENT",
 							"DELETING_AT_AGENT",
 							"DELETED_AT_AGENT",
@@ -1031,7 +1030,7 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 				name: "Example",
 				data: struct {
 					// Example ExampleJson `json:"example" graphql:"uri=http://localhost:30017/example-json-schema"`
-					Example ExampleJson `json:"example" graphql:"uri=http://example.com/example-json-schema"`
+					Example ExampleJson `json:"example"`
 				}{},
 			},
 			want: map[string]*parser.Struct{

--- a/cmd/struct-to-graphql/pkg/parser/parser_test.go
+++ b/cmd/struct-to-graphql/pkg/parser/parser_test.go
@@ -825,7 +825,7 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 				name: "Project",
 				data: struct {
 					AccountName string
-					Project     Project `json:",inline" graphql:"uri=k8s://projects.crds.kloudlite.io"`
+					Project     Project `json:",inline"`
 				}{},
 			},
 			want: map[string]*parser.Struct{
@@ -833,8 +833,8 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 					Types: map[string][]string{
 						"Project": {
 							"AccountName: String!",
-							"apiVersion: String!",
-							"kind: String!",
+							"apiVersion: String",
+							"kind: String",
 							"metadata: Metadata! @goField(name: \"objectMeta\")",
 							"spec: Github__com___kloudlite___api___cmd___struct____to____graphql___pkg___parser_test__ProjectSpec!",
 							"status: Github__com___kloudlite___operator___pkg___operator__Status",
@@ -842,6 +842,8 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 					},
 					Inputs: map[string][]string{
 						"ProjectIn": {
+							"apiVersion: String",
+							"kind: String",
 							"AccountName: String!",
 							"metadata: MetadataIn!",
 							"spec: Github__com___kloudlite___api___cmd___struct____to____graphql___pkg___parser_test__ProjectSpecIn!",
@@ -864,8 +866,8 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 							"generation: Int",
 						},
 						"Github__com___kloudlite___operator___pkg___operator__ResourceRef": {
-							"apiVersion: String!",
-							"kind: String!",
+							"apiVersion: String",
+							"kind: String",
 							"namespace: String!",
 							"name: String!",
 						},
@@ -1029,7 +1031,6 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 			args: args{
 				name: "Example",
 				data: struct {
-					// Example ExampleJson `json:"example" graphql:"uri=http://localhost:30017/example-json-schema"`
 					Example ExampleJson `json:"example"`
 				}{},
 			},
@@ -1050,8 +1051,8 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 				"common-types": {
 					Types: map[string][]string{
 						"Github__com___kloudlite___api___cmd___struct____to____graphql___pkg___parser_test__ExampleJson": {
-							"apiVersion: String!",
-							"kind: String!",
+							"apiVersion: String",
+							"kind: String",
 							"metadata: Metadata! @goField(name: \"objectMeta\")",
 							"Spec: Github__com___kloudlite___api___cmd___struct____to____graphql___pkg___parser_test__ExampleJsonSpec!",
 						},
@@ -1073,6 +1074,8 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 					},
 					Inputs: map[string][]string{
 						"Github__com___kloudlite___api___cmd___struct____to____graphql___pkg___parser_test__ExampleJsonIn": {
+							"apiVersion: String",
+							"kind: String",
 							"metadata: MetadataIn!",
 							"Spec: Github__com___kloudlite___api___cmd___struct____to____graphql___pkg___parser_test__ExampleJsonSpecIn!",
 						},
@@ -1334,6 +1337,66 @@ func Test_GeneratedGraphqlSchema(t *testing.T) {
 						},
 					},
 				},
+			},
+			wantErr: false,
+		},
+
+		{
+			name:   "test 24. overriding struct's omitempty json tags, with inline specified",
+			fields: fields{structs: map[string]*parser.Struct{}, schemaCli: schemaCli},
+			args: args{
+				name: "Sample",
+				data: struct {
+					//Type1 metav1.TypeMeta `json:"type1"`
+					//Type2 metav1.TypeMeta `json:"inline" graphql:"children-required"`
+					metav1.TypeMeta `json:",inline" graphql:"children-required"`
+				}{},
+			},
+			want: map[string]*parser.Struct{
+				"Sample": {
+					Types: map[string][]string{
+						"Sample": {
+							"apiVersion: String!",
+							"kind: String!",
+						},
+					},
+					Inputs: map[string][]string{
+						"SampleIn": {
+							"apiVersion: String!",
+							"kind: String!",
+						},
+					},
+				},
+				"common-types": {},
+			},
+			wantErr: false,
+		},
+
+		{
+			name:   "test 25. overriding struct's omitempty json tags, with inline specified",
+			fields: fields{structs: map[string]*parser.Struct{}, schemaCli: schemaCli},
+			args: args{
+				name: "Sample",
+				data: struct {
+					metav1.TypeMeta `json:",inline"`
+				}{},
+			},
+			want: map[string]*parser.Struct{
+				"Sample": {
+					Types: map[string][]string{
+						"Sample": {
+							"apiVersion: String",
+							"kind: String",
+						},
+					},
+					Inputs: map[string][]string{
+						"SampleIn": {
+							"apiVersion: String",
+							"kind: String",
+						},
+					},
+				},
+				"common-types": {},
 			},
 			wantErr: false,
 		},

--- a/cmd/struct-to-graphql/pkg/parser/types/kloudlite-custom-types.go
+++ b/cmd/struct-to-graphql/pkg/parser/types/kloudlite-custom-types.go
@@ -39,6 +39,11 @@ type TypeMeta struct {
 	Kind       string `json:"kind" graphql:"noinput"`
 }
 
+type TypeMeta2 struct {
+	APIVersion string `json:"apiVersion" graphql:"noinput"`
+	Kind       string `json:"kind" graphql:"noinput"`
+}
+
 //
 // func TypeMetaToGraphqlFieldEntry(omitEmpty bool) string {
 // 	required := ""

--- a/cmd/struct-to-graphql/pkg/parser/types/kloudlite-custom-types.go
+++ b/cmd/struct-to-graphql/pkg/parser/types/kloudlite-custom-types.go
@@ -33,30 +33,3 @@ func MetadataToGraphqlInputEntry(omitEmpty bool) string {
 	}
 	return fmt.Sprintf(`MetadataIn%s`, required)
 }
-
-type TypeMeta struct {
-	APIVersion string `json:"apiVersion" graphql:"noinput"`
-	Kind       string `json:"kind" graphql:"noinput"`
-}
-
-type TypeMeta2 struct {
-	APIVersion string `json:"apiVersion" graphql:"noinput"`
-	Kind       string `json:"kind" graphql:"noinput"`
-}
-
-//
-// func TypeMetaToGraphqlFieldEntry(omitEmpty bool) string {
-// 	required := ""
-// 	if !omitEmpty {
-// 		required = "!"
-// 	}
-// 	return fmt.Sprintf(`TypeMeta%s`, required)
-// }
-//
-// func TypeMetaToGraphqlInputEntry(omitEmpty bool) string {
-// 	required := ""
-// 	if !omitEmpty {
-// 		required = "!"
-// 	}
-// 	return fmt.Sprintf(`TypeMetaIn%s`, required)
-// }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -153,4 +153,6 @@ const (
 	ObservabilityTrackingKey    string = "kloudlite.io/observability.tracking.id"
 	ObservabilityAccountNameKey string = "kloudlite.io/observability.account.name"
 	ObservabilityClusterNameKey string = "kloudlite.io/observability.cluster.name"
+
+	ManagedByKloudlite string = "kloudlite.io/managed-by.kloudlite"
 )

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/net v0.17.0
 )
 
-require github.com/kloudlite/operator v0.0.0-20240111104606-97933f90de7b
+require github.com/kloudlite/operator v0.0.0-20240115050522-035b0feb841f
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/kloudlite/container-registry-authorizer v0.0.0-20231021122509-161dc30
 github.com/kloudlite/container-registry-authorizer v0.0.0-20231021122509-161dc30fde55/go.mod h1:GZj3wZmIw/qCciclRhgQTgmGiqe8wxoVzMXQjbOfnbc=
 github.com/kloudlite/operator v0.0.0-20240111104606-97933f90de7b h1:0Dg8VKotQvJUN/0zEf+wymxZOOl8DX/vs6aqfB3bcXM=
 github.com/kloudlite/operator v0.0.0-20240111104606-97933f90de7b/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
+github.com/kloudlite/operator v0.0.0-20240115050522-035b0feb841f h1:Smqaa+KMOfODyTWLh5mlrU5wMqwbxHtC8iC2tkSt7fU=
+github.com/kloudlite/operator v0.0.0-20240115050522-035b0feb841f/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/types/sync-status.go
+++ b/pkg/types/sync-status.go
@@ -12,7 +12,7 @@ type (
 type SyncStatus struct {
 	SyncScheduledAt time.Time  `json:"syncScheduledAt,omitempty"`
 	LastSyncedAt    time.Time  `json:"lastSyncedAt,omitempty"`
-  Action          SyncAction `json:"action"`
+	Action          SyncAction `json:"action"`
 	RecordVersion   int        `json:"recordVersion"`
 	State           SyncState  `json:"state"`
 	Error           *string    `json:"error,omitempty"`
@@ -24,13 +24,13 @@ const (
 )
 
 const (
-	SyncStateIdle                    SyncState = "IDLE"
-	SyncStateInQueue                 SyncState = "IN_QUEUE"
-	SyncStateAppliedAtAgent          SyncState = "APPLIED_AT_AGENT"
-	SyncStateErroredAtAgent          SyncState = "ERRORED_AT_AGENT"
-	SyncStateUpdatedAtAgent          SyncState = "UPDATED_AT_AGENT"
-	SyncStateDeletingAtAgent         SyncState = "DELETING_AT_AGENT"
-	SyncStateDeletedAtAgent          SyncState = "DELETED_AT_AGENT"
+	SyncStateIdle            SyncState = "IDLE"
+	SyncStateInQueue         SyncState = "IN_QUEUE"
+	SyncStateAppliedAtAgent  SyncState = "APPLIED_AT_AGENT"
+	SyncStateErroredAtAgent  SyncState = "ERRORED_AT_AGENT"
+	SyncStateUpdatedAtAgent  SyncState = "UPDATED_AT_AGENT"
+	SyncStateDeletingAtAgent SyncState = "DELETING_AT_AGENT"
+	SyncStateDeletedAtAgent  SyncState = "DELETED_AT_AGENT"
 )
 
 func GenSyncStatus(action SyncAction, recordVersion int) SyncStatus {


### PR DESCRIPTION
### Description

**HTTP CLI**
- In the `http-cli` component, there have been updates to GraphQL calls.

**Struct to GraphQL Converter**
- The `cmd/struct-to-graphql` component now includes the ability to override the `omitempty` property for inline structs. Tests have been updated to support this new feature.

**Infrastructure Management**
- The `apps/infra` component has received several updates, including:
  - Fixes to the upsert VPN device implementation.
  - Improvements to VPN device management.

**Console Application**
- The `apps/console` component has seen multiple changes:
  - Fixes and updates to API functionality.
  - Enhancements to resource synchronization.
  - Improved resource visibility in logs for the `process-resource-updates` function.
  - Fixes for inline `typeMeta` requirements.
  - Updates for resource mapping in hierarchical environments and projects.
  - API fixes for intercepting and applying updated app resources.

**Tenant Agent**
- In the `apps/tenant-agent` component, observability annotations for account names and cluster names are now added by default on every apply operation.