### PR TITLE
chore: bumps go version to v1.21.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700612854,
-        "narHash": "sha256-yrQ8osMD+vDLGFX7pcwsY/Qr5PUd6OmDMYJZzZi0+zc=",
+        "lastModified": 1705856552,
+        "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "19cbff58383a4ae384dea4d1d0c823d72b49d614",
+        "rev": "612f97239e2cc474c13c9dafa0df378058c5ad8d",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 
 require (
 	github.com/kloudlite/container-registry-authorizer v0.0.0-20231021122509-161dc30fde55
-	github.com/kloudlite/operator v0.0.0-20240116073010-358659b6c673
+	github.com/kloudlite/operator v0.0.0-20240124071634-f1e66969c02c
 	github.com/nats-io/nats.go v1.31.0
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/kloudlite/container-registry-authorizer v0.0.0-20231021122509-161dc30
 github.com/kloudlite/container-registry-authorizer v0.0.0-20231021122509-161dc30fde55/go.mod h1:GZj3wZmIw/qCciclRhgQTgmGiqe8wxoVzMXQjbOfnbc=
 github.com/kloudlite/operator v0.0.0-20240116073010-358659b6c673 h1:t3e61wr+c2jUzsNmAJx1aPsev5L+yL1rOtIj1KNZ9g0=
 github.com/kloudlite/operator v0.0.0-20240116073010-358659b6c673/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
+github.com/kloudlite/operator v0.0.0-20240124071634-f1e66969c02c h1:oo6k+eLZ8EULnjLtO0iGTLrw9pcBfWhqYnB8dGBaSvE=
+github.com/kloudlite/operator v0.0.0-20240124071634-f1e66969c02c/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
- bumps go from `v1.21.4` to `v1.21.5`
- also updates `github.com/kloudlite/operator` to latest `release-1.0.5`