### PR TITLE
Fix/nats key not found

### DIFF
--- a/apps/auth/Taskfile.yml
+++ b/apps/auth/Taskfile.yml
@@ -47,5 +47,6 @@ tasks:
       - |
         tdir=$(mktemp -d)
         task build Out=$tdir/{{.APP}}
-        podman buildx build -f ./Containerfile.local -t {{.IMAGE}} . --build-context builder=${tdir} --build-arg APP="{{.APP}}" --push
+        podman buildx build -f ./Containerfile.local -t {{.IMAGE}} . --build-context builder=${tdir} --build-arg APP="{{.APP}}" 
+        podman push {{.IMAGE}} 
         rm -rf $tdir

--- a/apps/console/internal/domain/project.go
+++ b/apps/console/internal/domain/project.go
@@ -3,10 +3,10 @@ package domain
 import (
 	"context"
 	"fmt"
+
 	"github.com/kloudlite/api/common/fields"
 	"github.com/kloudlite/api/pkg/errors"
 	fn "github.com/kloudlite/api/pkg/functions"
-	"github.com/kloudlite/api/pkg/kv"
 	"github.com/kloudlite/operator/operators/resource-watcher/types"
 	"github.com/kloudlite/operator/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +25,7 @@ func (d *domain) getClusterAttachedToProject(ctx K8sContext, projectName string)
 	cacheKey := fmt.Sprintf("account_name_%s-project_name_%s", ctx.GetAccountName(), projectName)
 
 	clusterName, err := d.consoleCacheStore.Get(ctx, cacheKey)
-	if err != nil && !errors.Is(err, kv.ErrKeyNotFound) {
+	if err != nil && !d.consoleCacheStore.ErrKeyNotFound(err) {
 		return nil, err
 	}
 

--- a/apps/console/internal/domain/vpn-device.go
+++ b/apps/console/internal/domain/vpn-device.go
@@ -431,8 +431,7 @@ func (d *domain) OnVPNDeviceDeleteMessage(ctx ConsoleContext, device entities.Co
 			return errors.NewE(err)
 		}
 
-		if _, err = d.iamClient.RemoveMembership(ctx, &iam.RemoveMembershipIn{
-			UserId:      string(ctx.UserId),
+		if _, err = d.iamClient.RemoveResource(ctx, &iam.RemoveResourceIn{
 			ResourceRef: iamT.NewResourceRef(ctx.AccountName, iamT.ResourceConsoleVPNDevice, device.Name),
 		}); err != nil {
 			return errors.NewE(err)

--- a/apps/infra/internal/domain/vpn-device.go
+++ b/apps/infra/internal/domain/vpn-device.go
@@ -326,8 +326,7 @@ func (d *domain) OnVPNDeviceDeleteMessage(ctx InfraContext, clusterName string, 
 		return errors.NewE(err)
 	}
 
-	if _, err = d.iamClient.RemoveMembership(ctx, &iam.RemoveMembershipIn{
-		UserId:      string(ctx.UserId),
+	if _, err = d.iamClient.RemoveResource(ctx, &iam.RemoveResourceIn{
 		ResourceRef: iamT.NewResourceRef(ctx.AccountName, iamT.ResourceInfraVPNDevice, device.Name),
 	}); err != nil {
 		return errors.NewE(err)

--- a/pkg/errors/main.go
+++ b/pkg/errors/main.go
@@ -2,9 +2,9 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/ztrue/tracerr"
-	"net/http"
 
 	"github.com/pkg/errors"
 )
@@ -32,6 +32,10 @@ func AssertNoError(err error, msg error) {
 
 func Is(err error, target error) bool {
 	return errors.Is(err, target)
+}
+
+func As(err error, target any) bool {
+	return errors.As(err, target)
 }
 
 func NewEf(err error, msg string, args ...any) error {

--- a/pkg/http-server/http-server.go
+++ b/pkg/http-server/http-server.go
@@ -3,13 +3,13 @@ package httpServer
 import (
 	"context"
 	"fmt"
-	"github.com/kloudlite/api/pkg/errors"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-	"github.com/ztrue/tracerr"
-
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/kloudlite/api/pkg/errors"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"github.com/ztrue/tracerr"
 
 	"github.com/99designs/gqlgen/graphql"
 	gqlHandler "github.com/99designs/gqlgen/graphql/handler"
@@ -111,16 +111,19 @@ func (s *server) SetupGraphqlServer(es graphql.ExecutableSchema, middlewares ...
 	s.All("/explorer", func(c *fiber.Ctx) error {
 		return c.Redirect(fmt.Sprintf("https://studio.apollographql.com/sandbox/explorer?endpoint=http://%s/query", c.Context().LocalAddr()))
 	})
+
 	s.All("/play", adaptor.HTTPHandler(playground.Handler("GraphQL playground", "/query")))
 	gqlServer := gqlHandler.NewDefaultServer(es)
 	for _, v := range middlewares {
 		s.Use(v)
 	}
+
 	gqlServer.SetErrorPresenter(func(ctx context.Context, err error) *gqlerror.Error {
 		if s.isDev {
 			tracerr.Print(err.(*gqlerror.Error).Unwrap())
 		}
 		return gqlerror.Errorf(err.Error())
 	})
+
 	s.All("/query", adaptor.HTTPHandlerFunc(gqlServer.ServeHTTP))
 }

--- a/pkg/http-server/http-session.go
+++ b/pkg/http-server/http-session.go
@@ -3,9 +3,10 @@ package httpServer
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/kloudlite/api/common"
 	"github.com/kloudlite/api/pkg/errors"
-	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/kloudlite/api/pkg/kv"
@@ -35,9 +36,9 @@ func NewSessionMiddleware(
 			var get any
 			get, err := repo.Get(ctx.Context(), key)
 			if err != nil {
-				if !errors.Is(err, kv.ErrKeyNotFound) {
+			  if !repo.ErrKeyNotFound(err) {
 					return errors.NewE(err)
-				}
+			  }
 			}
 
 			if get != nil {

--- a/pkg/kv/client.go
+++ b/pkg/kv/client.go
@@ -2,7 +2,6 @@ package kv
 
 import (
 	"context"
-	"github.com/kloudlite/api/pkg/errors"
 	"time"
 )
 
@@ -19,6 +18,7 @@ type Repo[T any] interface {
 	Set(c context.Context, key string, value T) error
 	SetWithExpiry(c context.Context, key string, value T, duration time.Duration) error
 	Get(c context.Context, key string) (T, error)
+	ErrKeyNotFound(err error) bool
 	Drop(c context.Context, key string) error
 }
 
@@ -26,7 +26,6 @@ type BinaryDataRepo interface {
 	Set(c context.Context, key string, value []byte) error
 	SetWithExpiry(c context.Context, key string, value []byte, duration time.Duration) error
 	Get(c context.Context, key string) ([]byte, error)
+	ErrKeyNotFound(err error) bool
 	Drop(c context.Context, key string) error
 }
-
-var ErrKeyNotFound = errors.New("key not found")

--- a/pkg/kv/nats-kv-repo.go
+++ b/pkg/kv/nats-kv-repo.go
@@ -15,7 +15,6 @@ import (
 type natsKVRepo[T any] struct {
 	keyValue jetstream.KeyValue
 }
-
 type Value[T any] struct {
 	Data      T
 	ExpiresAt time.Time
@@ -61,6 +60,10 @@ func (r *natsKVRepo[T]) Get(c context.Context, _key string) (T, error) {
 		return value.Data, errors.New("Key is expired")
 	}
 	return value.Data, errors.NewE(err)
+}
+
+func (r *natsKVRepo[T]) ErrKeyNotFound(err error) bool {
+	return errors.Is(err, jetstream.ErrKeyNotFound)
 }
 
 func sanitiseKey(key string) string {

--- a/pkg/kv/repo.go
+++ b/pkg/kv/repo.go
@@ -34,6 +34,10 @@ func (r *redisRepo[T]) Get(c context.Context, key string) (T, error) {
 	return value, errors.NewE(err)
 }
 
+func (r *redisRepo[T]) ErrKeyNotFound(err error) bool {
+	return errors.Is(err, redis.Nil)
+}
+
 func (r *redisRepo[T]) SetWithExpiry(c context.Context, key string, value T, duration time.Duration) error {
 	marshal, err := json.Marshal(value)
 	if err != nil {


### PR DESCRIPTION
## PR Description

- fixes error `nats: key not found`, emitting from `auth-api`, when a non-logged-in user is accessing it. Our previous implementation, had an incorrect call to check if session key is not found. This commit resolves it.

- On Deletion of resources `VPNDevice`, and `Environment`, all rolebindings for that resource should have been deleted, but we were missing it. This commit resolves it. 