### PR TITLE
Feat/restart apps and managed services

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-feature.md
+++ b/.github/ISSUE_TEMPLATE/0-feature.md
@@ -3,7 +3,7 @@ name: "✨ New Feature"
 about: Suggest an idea
 title: "✨ "
 labels: enhancement
-assignees: "karthik1729"
+assignees: "nxtcoder17"
 projects: Kloudlite
 
 ---

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -3,7 +3,7 @@ name: "🐛 Bug Report"
 about: Create a bug report to help us improve
 title: "🐛 "
 labels: bug
-assignees: karthik1729
+assignees: nxtcoder17
 projects: kloudlite
 
 ---
@@ -11,8 +11,7 @@ projects: kloudlite
 ### Describe the Bug
 ...
 
-### To Reproduce
-Steps to reproduce the behavior:
+### How To Reproduce
 1. ...
 2. ...
 

--- a/.tools/nvim/__http__/console/apps.graphql.yml
+++ b/.tools/nvim/__http__/console/apps.graphql.yml
@@ -16,6 +16,10 @@ query: |+ #graphql
             userId
             userName
           }
+          metadata {
+            name
+            annotations
+          }
           syncStatus {
             state
             action
@@ -149,4 +153,16 @@ variables:
   projectName: "{{.projectName}}"
   envName: "{{.envName}}"
   appName: "{{.name}}"
+---
+
+---
+label: restart app
+query: |+
+  query Query($projectName: String!, $envName: String!, $appName: String!) {
+    core_restartApp(projectName: $projectName, envName: $envName, appName: $appName)
+  }
+variables:
+  projectName: "{{.projectName}}"
+  envName: "{{.envName}}"
+  appName: "nginx"
 ---

--- a/.tools/nvim/__http__/console/project-managed-services.yml
+++ b/.tools/nvim/__http__/console/project-managed-services.yml
@@ -1,0 +1,29 @@
+---
+label: list project managed services
+query: |+
+  query Core_listProjectManagedServices($projectName: String!) {
+    core_listProjectManagedServices(projectName: $projectName) {
+      edges { 
+        node {
+          metadata {
+            name
+            annotations
+          }
+        }
+      }
+    }
+  }
+variables:
+  projectName: "{{.projectName}}"
+---
+
+label: restart project managed service
+query: |+ #graphql
+  query Query($projectName: String!, $name: String!) {
+    core_restartProjectManagedService(projectName: $projectName, name: $name)
+  }
+variables:
+  projectName: "{{.projectName}}"
+  name: "sampledbservice"
+
+---

--- a/.tools/nvim/__http__/infra/names.graphql.yml
+++ b/.tools/nvim/__http__/infra/names.graphql.yml
@@ -16,7 +16,7 @@ query: |+
 variables:
   resType: vpn_device
   # name: sample 
-  name: saple
+  name: sample
 ---
 
 label: Check Name Availability, with ClusterName

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,0 @@
-- [x] Helm Updates from BYOC Deployments from remote BYOC cluster
-- [] Creation of container registry protect and user (pull/push) on creation of account  (finance -> apply to k8s new Account)
-- [] Protected access needs to be changed to websockets (from remote cluster => kloudlite cluster)

--- a/apps/console/internal/app/graph/schema.graphqls
+++ b/apps/console/internal/app/graph/schema.graphqls
@@ -102,6 +102,7 @@ type Query {
     core_listApps(projectName: String!, envName: String!, search: SearchApps, pq: CursorPaginationIn): AppPaginatedRecords @isLoggedInAndVerified @hasAccount
     core_getApp(projectName: String!, envName: String!, name: String!): App @isLoggedInAndVerified @hasAccount
     core_resyncApp(projectName: String!, envName: String!, name: String!): Boolean! @isLoggedInAndVerified @hasAccount
+    core_restartApp(projectName: String!, envName: String!, appName: String!): Boolean! @isLoggedInAndVerified @hasAccount
 
     core_getConfigValues(projectName: String!, envName: String!, queries: [ConfigKeyRefIn]): [ConfigKeyValueRef!] @isLoggedInAndVerified @hasAccount
     core_listConfigs(projectName: String!, envName: String!, search: SearchConfigs, pq: CursorPaginationIn): ConfigPaginatedRecords @isLoggedInAndVerified @hasAccount
@@ -117,7 +118,6 @@ type Query {
     core_getRouter(projectName: String!, envName: String!, name: String!): Router @isLoggedInAndVerified @hasAccount
     core_resyncRouter(projectName: String!, envName: String!, name: String!): Boolean! @isLoggedInAndVerified @hasAccount
 
-
     core_getManagedResouceOutputKeys(projectName: String!, envName: String!, name: String!): [String!]! @isLoggedInAndVerified @hasAccount
     core_getManagedResouceOutputKeyValues(projectName: String!, envName: String!, keyrefs: [ManagedResourceKeyRefIn]): [ManagedResourceKeyValueRef!]! @isLoggedInAndVerified @hasAccount
     core_listManagedResources(projectName: String!, envName: String!, search: SearchManagedResources, pq: CursorPaginationIn): ManagedResourcePaginatedRecords @isLoggedInAndVerified @hasAccount
@@ -126,7 +126,8 @@ type Query {
 
     core_listProjectManagedServices(projectName: String!, search: SearchProjectManagedService, pq: CursorPaginationIn): ProjectManagedServicePaginatedRecords @isLoggedInAndVerified @hasAccount
     core_getProjectManagedService(projectName: String!,  name: String!): ProjectManagedService @isLoggedInAndVerified @hasAccount
-    core_resyncProjectManagedService(projectName: String!,  name: String!): Boolean! @isLoggedInAndVerified @hasAccount
+    core_resyncProjectManagedService(projectName: String!, name: String!): Boolean! @isLoggedInAndVerified @hasAccount
+    core_restartProjectManagedService(projectName: String!, name: String!): Boolean! @isLoggedInAndVerified @hasAccount
 
     core_listVPNDevices(search: CoreSearchVPNDevices, pq: CursorPaginationIn): ConsoleVPNDevicePaginatedRecords @isLoggedInAndVerified @hasAccount
     core_listVPNDevicesForUser: [ConsoleVPNDevice!] @isLoggedInAndVerified @hasAccount

--- a/apps/console/internal/app/graph/schema.resolvers.go
+++ b/apps/console/internal/app/graph/schema.resolvers.go
@@ -575,6 +575,18 @@ func (r *queryResolver) CoreResyncApp(ctx context.Context, projectName string, e
 	return true, nil
 }
 
+// CoreRestartApp is the resolver for the core_restartApp field.
+func (r *queryResolver) CoreRestartApp(ctx context.Context, projectName string, envName string, appName string) (bool, error) {
+	cc, err := toConsoleContext(ctx)
+	if err != nil {
+		return false, errors.NewE(err)
+	}
+	if err := r.Domain.RestartApp(newResourceContext(cc, projectName, envName), appName); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // CoreGetConfigValues is the resolver for the core_getConfigValues field.
 func (r *queryResolver) CoreGetConfigValues(ctx context.Context, projectName string, envName string, queries []*domain.ConfigKeyRef) ([]*domain.ConfigKeyValueRef, error) {
 	cc, err := toConsoleContext(ctx)
@@ -881,6 +893,19 @@ func (r *queryResolver) CoreResyncProjectManagedService(ctx context.Context, pro
 	return true, nil
 }
 
+// CoreRestartProjectManagedService is the resolver for the core_restartProjectManagedService field.
+func (r *queryResolver) CoreRestartProjectManagedService(ctx context.Context, projectName string, name string) (bool, error) {
+	cc, err := toConsoleContext(ctx)
+	if err != nil {
+		return false, errors.NewE(err)
+	}
+
+	if err := r.Domain.RestartProjectManagedService(cc, projectName, name); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // CoreListVPNDevices is the resolver for the core_listVPNDevices field.
 func (r *queryResolver) CoreListVPNDevices(ctx context.Context, search *model.CoreSearchVPNDevices, pq *repos.CursorPagination) (*model.ConsoleVPNDevicePaginatedRecords, error) {
 	filter := map[string]repos.MatchFilter{}
@@ -935,3 +960,13 @@ func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *mutationResolver) CoreRestartApp(ctx context.Context, projectName string, envName string, appName string) (bool, error) {
+	panic(fmt.Errorf("not implemented: CoreRestartApp - core_restartApp"))
+}

--- a/apps/console/internal/domain/api.go
+++ b/apps/console/internal/domain/api.go
@@ -2,8 +2,9 @@ package domain
 
 import (
 	"context"
-	"github.com/kloudlite/api/common/fields"
 	"time"
+
+	"github.com/kloudlite/api/common/fields"
 
 	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
 	wgv1 "github.com/kloudlite/operator/apis/wireguard/v1"
@@ -150,6 +151,7 @@ type Domain interface {
 	DeleteApp(ctx ResourceContext, name string) error
 
 	InterceptApp(ctx ResourceContext, appName string, deviceName string, intercept bool) (bool, error)
+	RestartApp(ctx ResourceContext, appName string) error
 
 	OnAppApplyError(ctx ResourceContext, errMsg string, name string, opts UpdateAndDeleteOpts) error
 	OnAppDeleteMessage(ctx ResourceContext, app entities.App) error
@@ -234,6 +236,9 @@ type Domain interface {
 	CreateProjectManagedService(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) (*entities.ProjectManagedService, error)
 	UpdateProjectManagedService(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) (*entities.ProjectManagedService, error)
 	DeleteProjectManagedService(ctx ConsoleContext, projectName string, name string) error
+
+	RestartProjectManagedService(ctx ConsoleContext, projectName string, name string) error
+
 	OnProjectManagedServiceApplyError(ctx ConsoleContext, projectName, name, errMsg string, opts UpdateAndDeleteOpts) error
 	OnProjectManagedServiceDeleteMessage(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) error
 	OnProjectManagedServiceUpdateMessage(ctx ConsoleContext, projectName string, service entities.ProjectManagedService, status types.ResourceStatus, opts UpdateAndDeleteOpts) error

--- a/apps/console/internal/domain/app.go
+++ b/apps/console/internal/domain/app.go
@@ -147,7 +147,6 @@ func (d *domain) UpdateApp(ctx ResourceContext, appIn entities.App) (*entities.A
 		ctx.DBFilters().Add(fields.MetadataName, appIn.Name),
 		patchForUpdate,
 	)
-	
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
@@ -178,6 +177,23 @@ func (d *domain) InterceptApp(ctx ResourceContext, appName string, deviceName st
 		return false, errors.NewE(err)
 	}
 	return true, nil
+}
+
+func (d *domain) RestartApp(ctx ResourceContext, appName string) error {
+	if err := d.canMutateResourcesInEnvironment(ctx); err != nil {
+		return errors.NewE(err)
+	}
+
+	app, err := d.findApp(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	if err := d.restartK8sResource(ctx, ctx.ProjectName, app.Namespace, app.GetEnsuredLabels()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (d *domain) OnAppUpdateMessage(ctx ResourceContext, app entities.App, status types.ResourceStatus, opts UpdateAndDeleteOpts) error {

--- a/apps/console/internal/domain/names.go
+++ b/apps/console/internal/domain/names.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+
 	"github.com/kloudlite/api/common/fields"
 
 	"github.com/kloudlite/api/apps/console/internal/entities"
@@ -22,7 +23,7 @@ func checkResourceName[T repos.Entity](ctx context.Context, filters repos.Filter
 
 	return &CheckNameAvailabilityOutput{
 		Result:         false,
-		SuggestedNames: fn.GenValidK8sResourceNames(filters[fields.Metadata].(string), 3),
+		SuggestedNames: fn.GenValidK8sResourceNames(filters[fields.MetadataName].(string), 3),
 	}, nil
 }
 

--- a/apps/infra/internal/app/process-resource-updates.go
+++ b/apps/infra/internal/app/process-resource-updates.go
@@ -65,19 +65,9 @@ func processResourceUpdates(consumer ReceiveResourceUpdatesConsumer, d domain.Do
 			return nil
 		}
 
-		obj := unstructured.Unstructured{Object: su.Object}
-		mLogger := logger.WithKV(
-			"gvk", obj.GetObjectKind().GroupVersionKind(),
-			"accountName/clusterName", fmt.Sprintf("%s/%s", su.AccountName, su.ClusterName),
-		)
-
-		mLogger.Infof("received message")
-		defer func() {
-			mLogger.Infof("processed message")
-		}()
-
 		dctx := domain.InfraContext{Context: context.TODO(), UserId: "sys-user-process-infra-updates", AccountName: su.AccountName}
 
+		obj := unstructured.Unstructured{Object: su.Object}
 		gvkStr := obj.GetObjectKind().GroupVersionKind().String()
 
 		resStatus, err := func() (types.ResourceStatus, error) {
@@ -95,6 +85,18 @@ func processResourceUpdates(consumer ReceiveResourceUpdatesConsumer, d domain.Do
 		if err != nil {
 			return err
 		}
+
+		mLogger := logger.WithKV(
+			"gvk", obj.GetObjectKind().GroupVersionKind(),
+			"NN", fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()),
+			"resource-status", resStatus,
+			"accountName/clusterName", fmt.Sprintf("%s/%s", su.AccountName, su.ClusterName),
+		)
+
+		mLogger.Infof("received message")
+		defer func() {
+			mLogger.Infof("processed message")
+		}()
 
 		switch gvkStr {
 		case clusterGVK.String():

--- a/apps/infra/internal/domain/helm-release.go
+++ b/apps/infra/internal/domain/helm-release.go
@@ -145,7 +145,6 @@ func (d *domain) UpdateHelmRelease(ctx InfraContext, clusterName string, hrIn en
 		&hrIn,
 		common.PatchOpts{
 			XPatch: repos.Document{
-				fc.HelmReleaseSpec:             hrIn.Spec,
 				fc.HelmReleaseSpecChartVersion: hrIn.Spec.ChartVersion,
 				fc.HelmReleaseSpecValues:       hrIn.Spec.Values,
 			},

--- a/apps/infra/internal/domain/nodepool.go
+++ b/apps/infra/internal/domain/nodepool.go
@@ -170,7 +170,8 @@ func (d *domain) UpdateNodePool(ctx InfraContext, clusterName string, nodePoolIn
 		&nodePoolIn,
 		common.PatchOpts{
 			XPatch: repos.Document{
-				fc.NodePoolSpec: nodePoolIn.Spec,
+				fc.NodePoolSpecMinCount: nodePoolIn.Spec.MinCount,
+				fc.NodePoolSpecMaxCount: nodePoolIn.Spec.MaxCount,
 			},
 		})
 

--- a/apps/infra/internal/domain/vpn-device.go
+++ b/apps/infra/internal/domain/vpn-device.go
@@ -122,7 +122,6 @@ func (d *domain) UpdateVPNDevice(ctx InfraContext, clusterName string, deviceIn 
 		&deviceIn,
 		common.PatchOpts{
 			XPatch: repos.Document{
-				fc.VPNDeviceSpec:                deviceIn.Spec,
 				fc.VPNDeviceSpecPorts:           deviceIn.Spec.Ports,
 				fc.VPNDeviceSpecActiveNamespace: deviceIn.Spec.ActiveNamespace,
 			},

--- a/apps/infra/internal/entities/helm-release.go
+++ b/apps/infra/internal/entities/helm-release.go
@@ -21,11 +21,11 @@ type HelmRelease struct {
 }
 
 func (h *HelmRelease) GetDisplayName() string {
-	return h.ResourceMetadata.DisplayName
+	return h.DisplayName
 }
 
 func (h *HelmRelease) GetStatus() operator.Status {
-	return operator.Status{}
+	return h.Status.Status
 }
 
 var HelmReleaseIndices = []repos.IndexField{

--- a/apps/tenant-agent/types/types.go
+++ b/apps/tenant-agent/types/types.go
@@ -3,8 +3,9 @@ package types
 type Action string
 
 const (
-	ActionApply  Action = "apply"
-	ActionDelete Action = "delete"
+	ActionApply   Action = "apply"
+	ActionDelete  Action = "delete"
+	ActionRestart Action = "restart"
 )
 
 type AgentMessage struct {

--- a/common/patch-util.go
+++ b/common/patch-util.go
@@ -41,7 +41,6 @@ func PatchForSyncFromAgent(
 	status types.ResourceStatus,
 	opts PatchOpts,
 ) repos.Document {
-	res.GetCreationTimestamp()
 	generatedPatch := repos.Document{
 		fields.MetadataCreationTimestamp: res.GetCreationTimestamp(),
 		fields.MetadataLabels:            res.GetLabels(),

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 
 require (
 	github.com/kloudlite/container-registry-authorizer v0.0.0-20231021122509-161dc30fde55
-	github.com/kloudlite/operator v0.0.0-20240124071634-f1e66969c02c
+	github.com/kloudlite/operator v0.0.0-20240125192852-5c63464fe989
 	github.com/nats-io/nats.go v1.31.0
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/kloudlite/operator v0.0.0-20240116073010-358659b6c673 h1:t3e61wr+c2jU
 github.com/kloudlite/operator v0.0.0-20240116073010-358659b6c673/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
 github.com/kloudlite/operator v0.0.0-20240124071634-f1e66969c02c h1:oo6k+eLZ8EULnjLtO0iGTLrw9pcBfWhqYnB8dGBaSvE=
 github.com/kloudlite/operator v0.0.0-20240124071634-f1e66969c02c/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
+github.com/kloudlite/operator v0.0.0-20240125192852-5c63464fe989 h1:mHshQnMCWiqpHwYn87ARpYRVyN57q0ksOKCM4wXmeHc=
+github.com/kloudlite/operator v0.0.0-20240125192852-5c63464fe989/go.mod h1:eD8xKzwOVtajAglELcEHn2XL4H22ERBLT2uaisA6SzQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
### PR Description

**Chore: Update `kloudlite/operator`**
- The `kloudlite/operator` module has been updated to the latest release (v1.0.5). This update brings support for restarting managed services, enhancing the overall functionality of the application.

**GitHub Issue Template**
- Documentation has been improved by updating the GitHub issue template to specify assignees more effectively. This change streamlines the issue management process.

**Feature: Restart API**
- A new feature has been added to the project that introduces an API for restarting both apps and project managed services. The `apps/tenant-agent` now includes an action called `restart` in addition to `apply` and `delete`.

**Fix: GraphQL Updates**
- Fixes have been made to the GraphQL update process for node pools and infra VPN devices in the `apps/infra` module

**Fix: Helm Release Status**
- A fix has been applied to the `apps/infra` module to address missing status in Helm releases. This ensures that the status information is accurately represented.

