### PR TITLE
ci: updates image building scripts

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -117,4 +117,4 @@ jobs:
 
           cd .github/workflows/container-build
           task go-container-build Image="$image_name:$IMAGE_TAG"
-          task go-container-build Image="$image_name:commit-${GITHUB_SHA}"
+          # task go-container-build Image="$image_name:commit-${GITHUB_SHA}"

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -107,13 +107,17 @@ jobs:
       - name: Build & Push Image
         if: startsWith(github.ref, 'refs/heads/release')
         run: |
+          set -e
           image_name="ghcr.io/kloudlite/api/${{matrix.app}}"
 
           docker manifest inspect $image_name:$IMAGE_TAG
-          if [ $? -eq 0 ]; then
+          exit_status=$?
+          if [ $exit_status -eq 0 ]; then
             [ "$OVERRIDE_PUSHED_IMAGE" = "false" ] && echo "image ($image_name:$IMAGE_TAG) already exists, and override image is disable, exiting" && exit 0
             echo "image exists, but override pushed image is set to true. proceeding with building image"
           fi
+
+          set +e
 
           cd .github/workflows/container-build
           task go-container-build Image="$image_name:$IMAGE_TAG"

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -111,8 +111,8 @@ jobs:
 
           docker manifest inspect $image_name:$IMAGE_TAG
           if [ $? -eq 0 ]; then
-            echo "image already exists"
             [ "$OVERRIDE_PUSHED_IMAGE" = "false" ] && echo "image ($image_name:$IMAGE_TAG) already exists, and override image is disable, exiting" && exit 0
+            echo "image exists, but override pushed image is set to true. proceeding with building image"
           fi
 
           cd .github/workflows/container-build

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -6,6 +6,7 @@ on:
   repository_dispatch:
     types:
       - webhook
+
   push:
     paths:
       - "apps/**/**"
@@ -57,9 +58,9 @@ jobs:
             ${{ runner.os }}-golang-
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.21.5
 
       - name: Install Task
         uses: arduino/setup-task@v1
@@ -82,7 +83,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        # uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -90,15 +92,29 @@ jobs:
 
       - name: Create Image Tags
         run: |
-          echo "BRANCH_TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')" >> $GITHUB_ENV
+          IMAGE_TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/release-//g')
+
+          OVERRIDE_PUSHED_IMAGE=false
+
+          echo "$IMAGE_TAG" | grep -i '\-nightly$'
+          if [ $? -eq 0 ]; then
+            OVERRIDE_PUSHED_IMAGE=true
+          fi
+
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "OVERRIDE_PUSHED_IMAGE=$OVERRIDE_PUSHED_IMAGE" >> $GITHUB_ENV
 
       - name: Build & Push Image
         if: startsWith(github.ref, 'refs/heads/release')
         run: |
+          image_name="ghcr.io/kloudlite/api/${{matrix.app}}"
 
-          branch_name=${GITHUB_REF#refs/heads/}
-          version_string="v${branch_name#release-}-nightly"
-          
+          docker manifest inspect $image_name:$IMAGE_TAG
+          if [ $? -eq 0 ]; then
+            echo "image already exists"
+            [ "$OVERRIDE_PUSHED_IMAGE" = "false" ] && echo "image ($image_name:$IMAGE_TAG) already exists, and override image is disable, exiting" && exit 0
+          fi
+
           cd .github/workflows/container-build
-          task go-container-build Image="ghcr.io/kloudlite/api/${{matrix.app}}:$version_string"
-          task go-container-build Image="ghcr.io/kloudlite/api/${{matrix.app}}:commit-${GITHUB_SHA}"
+          task go-container-build Image="$image_name:$IMAGE_TAG"
+          task go-container-build Image="$image_name:commit-${GITHUB_SHA}"


### PR DESCRIPTION
- also ensures non `-nightly` branch images are immutable, and should never be rebuilt and pushed to container registries
