### PR TITLE
Fix/observability

### DIFF
--- a/apps/infra/internal/domain/clusters.go
+++ b/apps/infra/internal/domain/clusters.go
@@ -399,7 +399,7 @@ func (d *domain) syncKloudliteDeviceOnCluster(ctx InfraContext, gvpnName string)
 	}
 
 	// 2. Grab wireguard config from that device
-	wgConfig, err := d.getGlobalVPNDeviceWgConfig(ctx, gv.Name, gv.KloudliteDevice.Name)
+	wgConfig, err := d.getGlobalVPNDeviceWgConfig(ctx, gv.Name, gv.KloudliteDevice.Name, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/infra/internal/domain/global-vpn-cluster-connection.go
+++ b/apps/infra/internal/domain/global-vpn-cluster-connection.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	gvpnConnectionDeviceMethod = "gvpn-connection"
+	gvpnConnectionDeviceMethod     = "gvpn-connection"
+	kloudliteGlobalVPNDeviceMethod = "kloudlite-global-vpn-device"
 )
 
 func (d *domain) getGlobalVPNConnectionPeers(vpns []*entities.GlobalVPNConnection) ([]wgv1.Peer, error) {

--- a/apps/infra/internal/domain/global-vpn.go
+++ b/apps/infra/internal/domain/global-vpn.go
@@ -48,14 +48,14 @@ func (d *domain) createGlobalVPN(ctx InfraContext, gvpn entities.GlobalVPN) (*en
 			Name: kloudliteGlobalVPNDevice,
 		},
 		ResourceMetadata: common.ResourceMetadata{
-			DisplayName:   "kloudlite-platform-device",
+			DisplayName:   kloudliteGlobalVPNDevice,
 			CreatedBy:     common.CreatedOrUpdatedByKloudlite,
 			LastUpdatedBy: common.CreatedOrUpdatedByKloudlite,
 		},
 		AccountName:    ctx.AccountName,
 		GlobalVPNName:  gv.Name,
 		PublicEndpoint: nil,
-		CreationMethod: gvpnConnectionDeviceMethod,
+		CreationMethod: kloudliteGlobalVPNDevice,
 	})
 	if err != nil {
 		return nil, err

--- a/apps/infra/internal/domain/templates/global-vpn-kloudlite-device.yml.tpl
+++ b/apps/infra/internal/domain/templates/global-vpn-kloudlite-device.yml.tpl
@@ -68,6 +68,7 @@ spec:
             capabilities:
               add:
                 - NET_ADMIN
+                - SYS_MODULE
             privileged: true
           volumeMounts:
             - mountPath: /config/wg_confs/wg0.conf
@@ -114,7 +115,6 @@ spec:
               memory: 100Mi
 
       dnsPolicy: ClusterFirst
-
       volumes:
         - name: wg-config
           secret:

--- a/apps/observability/internal/env/env.go
+++ b/apps/observability/internal/env/env.go
@@ -19,6 +19,8 @@ type Env struct {
 	IsDev bool
 
 	KubernetesApiProxy string `env:"KUBERNETES_API_PROXY"`
+
+	GlobalVPNAuthzSecret string `env:"GLOBAL_VPN_AUTHZ_SECRET" required:"true"`
 }
 
 func LoadEnv() (*Env, error) {

--- a/pkg/functions/list.go
+++ b/pkg/functions/list.go
@@ -1,0 +1,10 @@
+package functions
+
+func Reduce[T any, V any](items []T, reducerFn func(V, T), value V) V {
+	for i := range items {
+		item := items[i]
+		reducerFn(value, item)
+	}
+
+	return value
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -72,6 +72,7 @@ func New(options *Options) (Logger, error) {
 			return cfg
 		}
 		pcfg := zap.NewProductionEncoderConfig()
+		pcfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		pcfg.TimeKey = ""
 		pcfg.LineEnding = "\n"
 		return pcfg
@@ -100,9 +101,6 @@ func New(options *Options) (Logger, error) {
 	}
 
 	lgr := zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(cfg), os.Stdout, loglevel), zapOpts...)
-
-	cLogger := &logger{
-		zapLogger: lgr.Sugar(),
-	}
+	cLogger := &logger{zapLogger: lgr.Sugar()}
 	return cLogger, nil
 }

--- a/pkg/repos/db-repo.go
+++ b/pkg/repos/db-repo.go
@@ -45,16 +45,19 @@ type Query struct {
 type MatchType string
 
 const (
-	MatchTypeExact = "exact"
-	MatchTypeArray = "array"
-	MatchTypeRegex = "regex"
+	MatchTypeExact      = "exact"
+	MatchTypeArray      = "array"
+	MatchTypeNotInArray = "not-in-array"
+	MatchTypeRegex      = "regex"
 )
 
 type MatchFilter struct {
-	MatchType MatchType `json:"matchType" graphql:"enum=exact;array;regex;"`
-	Exact     any       `json:"exact,omitempty"`
-	Array     []any     `json:"array,omitempty"`
-	Regex     *string   `json:"regex,omitempty"`
+	// MatchType  MatchType `json:"matchType" graphql:"enum=exact;array;regex;"`
+	MatchType  MatchType `json:"matchType"`
+	Exact      any       `json:"exact,omitempty"`
+	Array      []any     `json:"array,omitempty"`
+	NotInArray []any     `json:"notInArray,omitempty"`
+	Regex      *string   `json:"regex,omitempty"`
 }
 
 type ID string
@@ -113,7 +116,7 @@ type DbRepo[T Entity] interface {
 	DeleteOne(ctx context.Context, filter Filter) error
 
 	ErrAlreadyExists(err error) bool
-	MergeMatchFilters(filter Filter, matchFilters map[string]MatchFilter) Filter
+	MergeMatchFilters(filter Filter, matchFilters ...map[string]MatchFilter) Filter
 }
 
 type indexOrder bool

--- a/pkg/wgutils/peer-config.go
+++ b/pkg/wgutils/peer-config.go
@@ -21,6 +21,9 @@ type WgConfigParams struct {
 	PrivateKey string
 	DNS        string
 
+	PostUp   []string
+	PostDown []string
+
 	PublicPeers  []PublicPeer
 	PrivatePeers []PrivatePeer
 }
@@ -32,6 +35,14 @@ func GenerateWireguardConfig(wgParams WgConfigParams) (string, error) {
 Address = {{.IPAddr}}/32
 PrivateKey = {{.PrivateKey}}
 DNS = {{.DNS}}
+
+{{- range .PostUp -}}
+PostUp = {{.}}
+{{- end -}}
+
+{{- range .PostDown -}}
+PostDown = {{.}}
+{{- end -}}
 
 {{- range .PublicPeers}}
 {{- with .}}


### PR DESCRIPTION
Resolves kloudlite/kloudlite#215

- observability API now communicates to target clusters via global VPN proxy, to fetch the list of currently running pods.

- metrics and logs will now be shown only for currently running pods