### PR TITLE
Refactor/imported mres

### DIFF
--- a/apps/console/internal/app/graph/generated/generated.go
+++ b/apps/console/internal/app/graph/generated/generated.go
@@ -697,7 +697,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CoreCloneEnvironment              func(childComplexity int, sourceEnvName string, destinationEnvName string, displayName string, environmentRoutingMode v1.EnvironmentRoutingMode) int
+		CoreCloneEnvironment              func(childComplexity int, clusterName string, sourceEnvName string, destinationEnvName string, displayName string, environmentRoutingMode v1.EnvironmentRoutingMode) int
 		CoreCreateApp                     func(childComplexity int, envName string, app entities.App) int
 		CoreCreateConfig                  func(childComplexity int, envName string, config entities.Config) int
 		CoreCreateEnvironment             func(childComplexity int, env entities.Environment) int
@@ -956,7 +956,7 @@ type MutationResolver interface {
 	CoreCreateEnvironment(ctx context.Context, env entities.Environment) (*entities.Environment, error)
 	CoreUpdateEnvironment(ctx context.Context, env entities.Environment) (*entities.Environment, error)
 	CoreDeleteEnvironment(ctx context.Context, envName string) (bool, error)
-	CoreCloneEnvironment(ctx context.Context, sourceEnvName string, destinationEnvName string, displayName string, environmentRoutingMode v1.EnvironmentRoutingMode) (*entities.Environment, error)
+	CoreCloneEnvironment(ctx context.Context, clusterName string, sourceEnvName string, destinationEnvName string, displayName string, environmentRoutingMode v1.EnvironmentRoutingMode) (*entities.Environment, error)
 	CoreCreateImagePullSecret(ctx context.Context, pullSecret entities.ImagePullSecret) (*entities.ImagePullSecret, error)
 	CoreUpdateImagePullSecret(ctx context.Context, pullSecret entities.ImagePullSecret) (*entities.ImagePullSecret, error)
 	CoreDeleteImagePullSecret(ctx context.Context, name string) (bool, error)
@@ -3813,7 +3813,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CoreCloneEnvironment(childComplexity, args["sourceEnvName"].(string), args["destinationEnvName"].(string), args["displayName"].(string), args["environmentRoutingMode"].(v1.EnvironmentRoutingMode)), true
+		return e.complexity.Mutation.CoreCloneEnvironment(childComplexity, args["clusterName"].(string), args["sourceEnvName"].(string), args["destinationEnvName"].(string), args["displayName"].(string), args["environmentRoutingMode"].(v1.EnvironmentRoutingMode)), true
 
 	case "Mutation.core_createApp":
 		if e.complexity.Mutation.CoreCreateApp == nil {
@@ -5380,7 +5380,7 @@ type Mutation {
 	core_createEnvironment(env: EnvironmentIn!): Environment @isLoggedInAndVerified @hasAccount
 	core_updateEnvironment(env: EnvironmentIn!): Environment @isLoggedInAndVerified @hasAccount
 	core_deleteEnvironment(envName: String!): Boolean! @isLoggedInAndVerified @hasAccount
-	core_cloneEnvironment(sourceEnvName: String!, destinationEnvName: String!, displayName: String!, environmentRoutingMode: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentRoutingMode!): Environment @isLoggedInAndVerified @hasAccount
+	core_cloneEnvironment(clusterName: String!, sourceEnvName: String!, destinationEnvName: String!, displayName: String!, environmentRoutingMode: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentRoutingMode!): Environment @isLoggedInAndVerified @hasAccount
 
 	# image pull secrets
 	core_createImagePullSecret(pullSecret: ImagePullSecretIn!): ImagePullSecret @isLoggedInAndVerified @hasAccount
@@ -6765,41 +6765,50 @@ func (ec *executionContext) field_Mutation_core_cloneEnvironment_args(ctx contex
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
-	if tmp, ok := rawArgs["sourceEnvName"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceEnvName"))
+	if tmp, ok := rawArgs["clusterName"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clusterName"))
 		arg0, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["sourceEnvName"] = arg0
+	args["clusterName"] = arg0
 	var arg1 string
-	if tmp, ok := rawArgs["destinationEnvName"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destinationEnvName"))
+	if tmp, ok := rawArgs["sourceEnvName"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceEnvName"))
 		arg1, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["destinationEnvName"] = arg1
+	args["sourceEnvName"] = arg1
 	var arg2 string
-	if tmp, ok := rawArgs["displayName"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
+	if tmp, ok := rawArgs["destinationEnvName"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destinationEnvName"))
 		arg2, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["displayName"] = arg2
-	var arg3 v1.EnvironmentRoutingMode
-	if tmp, ok := rawArgs["environmentRoutingMode"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentRoutingMode"))
-		arg3, err = ec.unmarshalNGithub__com___kloudlite___operator___apis___crds___v1__EnvironmentRoutingMode2githubᚗcomᚋkloudliteᚋoperatorᚋapisᚋcrdsᚋv1ᚐEnvironmentRoutingMode(ctx, tmp)
+	args["destinationEnvName"] = arg2
+	var arg3 string
+	if tmp, ok := rawArgs["displayName"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
+		arg3, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["environmentRoutingMode"] = arg3
+	args["displayName"] = arg3
+	var arg4 v1.EnvironmentRoutingMode
+	if tmp, ok := rawArgs["environmentRoutingMode"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentRoutingMode"))
+		arg4, err = ec.unmarshalNGithub__com___kloudlite___operator___apis___crds___v1__EnvironmentRoutingMode2githubᚗcomᚋkloudliteᚋoperatorᚋapisᚋcrdsᚋv1ᚐEnvironmentRoutingMode(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["environmentRoutingMode"] = arg4
 	return args, nil
 }
 
@@ -26382,7 +26391,7 @@ func (ec *executionContext) _Mutation_core_cloneEnvironment(ctx context.Context,
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().CoreCloneEnvironment(rctx, fc.Args["sourceEnvName"].(string), fc.Args["destinationEnvName"].(string), fc.Args["displayName"].(string), fc.Args["environmentRoutingMode"].(v1.EnvironmentRoutingMode))
+			return ec.resolvers.Mutation().CoreCloneEnvironment(rctx, fc.Args["clusterName"].(string), fc.Args["sourceEnvName"].(string), fc.Args["destinationEnvName"].(string), fc.Args["displayName"].(string), fc.Args["environmentRoutingMode"].(v1.EnvironmentRoutingMode))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.IsLoggedInAndVerified == nil {

--- a/apps/console/internal/app/graph/matchfilter.resolvers.go
+++ b/apps/console/internal/app/graph/matchfilter.resolvers.go
@@ -10,17 +10,39 @@ import (
 
 	"github.com/kloudlite/api/apps/console/internal/app/graph/generated"
 	"github.com/kloudlite/api/apps/console/internal/app/graph/model"
+	"github.com/kloudlite/api/pkg/functions"
 	"github.com/kloudlite/api/pkg/repos"
 )
 
 // MatchType is the resolver for the matchType field.
 func (r *matchFilterResolver) MatchType(ctx context.Context, obj *repos.MatchFilter) (model.GithubComKloudliteAPIPkgReposMatchType, error) {
-	panic(fmt.Errorf("not implemented: MatchType - matchType"))
+	if obj == nil {
+		return "", fmt.Errorf("obj == nil")
+	}
+
+	return functions.JsonConvert[model.GithubComKloudliteAPIPkgReposMatchType](obj.MatchType)
 }
 
 // MatchType is the resolver for the matchType field.
 func (r *matchFilterInResolver) MatchType(ctx context.Context, obj *repos.MatchFilter, data model.GithubComKloudliteAPIPkgReposMatchType) error {
-	panic(fmt.Errorf("not implemented: MatchType - matchType"))
+	if obj == nil {
+		return fmt.Errorf("obj == nil")
+	}
+
+	switch data {
+	case "exact":
+		obj.MatchType = repos.MatchTypeExact
+	case "array":
+		obj.MatchType = repos.MatchTypeArray
+	case "not_in_array":
+		obj.MatchType = repos.MatchTypeNotInArray
+	case "regex":
+		obj.MatchType = repos.MatchTypeRegex
+	default:
+		return fmt.Errorf("unknown value for MatchType: %v", data)
+	}
+
+	return nil
 }
 
 // MatchFilter returns generated.MatchFilterResolver implementation.

--- a/apps/console/internal/app/graph/model/models_gen.go
+++ b/apps/console/internal/app/graph/model/models_gen.go
@@ -748,6 +748,7 @@ type SearchImagePullSecrets struct {
 type SearchManagedResources struct {
 	Text               *repos.MatchFilter `json:"text,omitempty"`
 	ManagedServiceName *repos.MatchFilter `json:"managedServiceName,omitempty"`
+	EnvName            *repos.MatchFilter `json:"envName,omitempty"`
 	IsReady            *repos.MatchFilter `json:"isReady,omitempty"`
 	MarkedForDeletion  *repos.MatchFilter `json:"markedForDeletion,omitempty"`
 }

--- a/apps/console/internal/app/graph/resolver-utils.go
+++ b/apps/console/internal/app/graph/resolver-utils.go
@@ -103,6 +103,6 @@ func newResourceContext(ctx domain.ConsoleContext, environmentName string) domai
 	return domain.ResourceContext{ConsoleContext: ctx, EnvironmentName: environmentName}
 }
 
-func newMresContext(ctx domain.ConsoleContext, msvcName string) domain.ManagedResourceContext {
-	return domain.ManagedResourceContext{ConsoleContext: ctx, ManagedServiceName: msvcName}
+func newMresContext(ctx domain.ConsoleContext, msvcName *string, envName *string) domain.ManagedResourceContext {
+	return domain.ManagedResourceContext{ConsoleContext: ctx, ManagedServiceName: msvcName, EnvironmentName: envName}
 }

--- a/apps/console/internal/app/graph/schema.graphqls
+++ b/apps/console/internal/app/graph/schema.graphqls
@@ -152,7 +152,7 @@ type Mutation {
 	core_createEnvironment(env: EnvironmentIn!): Environment @isLoggedInAndVerified @hasAccount
 	core_updateEnvironment(env: EnvironmentIn!): Environment @isLoggedInAndVerified @hasAccount
 	core_deleteEnvironment(envName: String!): Boolean! @isLoggedInAndVerified @hasAccount
-	core_cloneEnvironment(sourceEnvName: String!, destinationEnvName: String!, displayName: String!, environmentRoutingMode: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentRoutingMode!): Environment @isLoggedInAndVerified @hasAccount
+	core_cloneEnvironment(clusterName: String!, sourceEnvName: String!, destinationEnvName: String!, displayName: String!, environmentRoutingMode: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentRoutingMode!): Environment @isLoggedInAndVerified @hasAccount
 
 	# image pull secrets
 	core_createImagePullSecret(pullSecret: ImagePullSecretIn!): ImagePullSecret @isLoggedInAndVerified @hasAccount

--- a/apps/console/internal/app/graph/schema.graphqls
+++ b/apps/console/internal/app/graph/schema.graphqls
@@ -69,6 +69,7 @@ input SearchRouters {
 input SearchManagedResources {
 	text: MatchFilterIn
 	managedServiceName: MatchFilterIn
+	envName: MatchFilterIn
 	isReady: MatchFilterIn
 	markedForDeletion: MatchFilterIn
 }
@@ -125,13 +126,13 @@ type Query {
 	core_getRouter(envName: String!, name: String!): Router @isLoggedInAndVerified @hasAccount
 	core_resyncRouter(envName: String!, name: String!): Boolean! @isLoggedInAndVerified @hasAccount
 
-	core_getManagedResouceOutputKeys(msvcName: String!, name: String!): [String!]! @isLoggedInAndVerified @hasAccount
-	core_getManagedResouceOutputKeyValues(msvcName: String!, keyrefs: [ManagedResourceKeyRefIn]): [ManagedResourceKeyValueRef!]! @isLoggedInAndVerified @hasAccount
-	core_listManagedResources(msvcName: String! ,search: SearchManagedResources, pq: CursorPaginationIn): ManagedResourcePaginatedRecords @isLoggedInAndVerified @hasAccount
-	core_getManagedResource(msvcName: String!, name: String!): ManagedResource @isLoggedInAndVerified @hasAccount
+	core_getManagedResouceOutputKeys(msvcName: String, envName:String , name: String!): [String!]! @isLoggedInAndVerified @hasAccount
+	core_getManagedResouceOutputKeyValues(msvcName: String, envName:String, keyrefs: [ManagedResourceKeyRefIn]): [ManagedResourceKeyValueRef!]! @isLoggedInAndVerified @hasAccount
+	core_listManagedResources(search: SearchManagedResources, pq: CursorPaginationIn): ManagedResourcePaginatedRecords @isLoggedInAndVerified @hasAccount
+	core_getManagedResource(msvcName: String, envName: String, name: String!): ManagedResource @isLoggedInAndVerified @hasAccount
 	core_resyncManagedResource(msvcName: String!, name: String!): Boolean! @isLoggedInAndVerified @hasAccount
-	core_listImportedManagedResources(envName: String! ,search: SearchManagedResources, pq: CursorPaginationIn): ManagedResourcePaginatedRecords @isLoggedInAndVerified @hasAccount
-	core_getImportedManagedResource(envName: String!, name: String!): ManagedResource @isLoggedInAndVerified @hasAccount
+	# core_listImportedManagedResources(envName: String! ,search: SearchManagedResources, pq: CursorPaginationIn): ManagedResourcePaginatedRecords @isLoggedInAndVerified @hasAccount
+	# core_getImportedManagedResource(envName: String!, name: String!): ManagedResource @isLoggedInAndVerified @hasAccount
 
 	# core_listProjectManagedServices(search: SearchProjectManagedService, pq: CursorPaginationIn): ProjectManagedServicePaginatedRecords @isLoggedInAndVerified @hasAccount
 	# core_getProjectManagedService( name: String!): ProjectManagedService @isLoggedInAndVerified @hasAccount

--- a/apps/console/internal/app/graph/schema.resolvers.go
+++ b/apps/console/internal/app/graph/schema.resolvers.go
@@ -288,7 +288,7 @@ func (r *mutationResolver) CoreCreateManagedResource(ctx context.Context, msvcNa
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
-	return r.Domain.CreateManagedResource(newMresContext(cc, msvcName), mres)
+	return r.Domain.CreateManagedResource(newMresContext(cc, &msvcName, nil), mres)
 }
 
 // CoreUpdateManagedResource is the resolver for the core_updateManagedResource field.
@@ -297,7 +297,7 @@ func (r *mutationResolver) CoreUpdateManagedResource(ctx context.Context, msvcNa
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
-	return r.Domain.UpdateManagedResource(newMresContext(cc, msvcName), mres)
+	return r.Domain.UpdateManagedResource(newMresContext(cc, &msvcName, nil), mres)
 }
 
 // CoreDeleteManagedResource is the resolver for the core_deleteManagedResource field.
@@ -306,7 +306,7 @@ func (r *mutationResolver) CoreDeleteManagedResource(ctx context.Context, msvcNa
 	if err != nil {
 		return false, errors.NewE(err)
 	}
-	if err := r.Domain.DeleteManagedResource(newMresContext(cc, msvcName), mresName); err != nil {
+	if err := r.Domain.DeleteManagedResource(newMresContext(cc, &msvcName, nil), mresName); err != nil {
 		return false, errors.NewE(err)
 	}
 	return true, nil
@@ -318,7 +318,8 @@ func (r *mutationResolver) CoreImportManagedResource(ctx context.Context, envNam
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
-	return r.Domain.ImportManagedResource(newMresContext(cc, msvcName), mresName, envName)
+
+	return r.Domain.ImportManagedResource(newMresContext(cc, &msvcName, &envName), mresName)
 }
 
 // CoreDeleteImportedManagedResource is the resolver for the core_deleteImportedManagedResource field.
@@ -818,16 +819,21 @@ func (r *queryResolver) CoreResyncRouter(ctx context.Context, envName string, na
 }
 
 // CoreGetManagedResouceOutputKeys is the resolver for the core_getManagedResouceOutputKeys field.
-func (r *queryResolver) CoreGetManagedResouceOutputKeys(ctx context.Context, msvcName string, name string) ([]string, error) {
+func (r *queryResolver) CoreGetManagedResouceOutputKeys(ctx context.Context, msvcName *string, envName *string, name string) ([]string, error) {
 	cc, err := toConsoleContext(ctx)
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
-	return r.Domain.GetManagedResourceOutputKeys(newMresContext(cc, msvcName), name)
+
+	if msvcName == nil && envName == nil {
+		return nil, errors.New("must specify either msvcName or envName")
+	}
+
+	return r.Domain.GetManagedResourceOutputKeys(newMresContext(cc, msvcName, envName), name)
 }
 
 // CoreGetManagedResouceOutputKeyValues is the resolver for the core_getManagedResouceOutputKeyValues field.
-func (r *queryResolver) CoreGetManagedResouceOutputKeyValues(ctx context.Context, msvcName string, keyrefs []*domain.ManagedResourceKeyRef) ([]*domain.ManagedResourceKeyValueRef, error) {
+func (r *queryResolver) CoreGetManagedResouceOutputKeyValues(ctx context.Context, msvcName *string, envName *string, keyrefs []*domain.ManagedResourceKeyRef) ([]*domain.ManagedResourceKeyValueRef, error) {
 	cc, err := toConsoleContext(ctx)
 	if err != nil {
 		return nil, errors.NewE(err)
@@ -838,16 +844,25 @@ func (r *queryResolver) CoreGetManagedResouceOutputKeyValues(ctx context.Context
 		m[i] = *keyrefs[i]
 	}
 
-	return r.Domain.GetManagedResourceOutputKVs(newMresContext(cc, msvcName), m)
+	if msvcName == nil && envName == nil {
+		return nil, errors.New("must specify either msvcName or envName")
+	}
+
+	return r.Domain.GetManagedResourceOutputKVs(newMresContext(cc, msvcName, envName), m)
 }
 
 // CoreListManagedResources is the resolver for the core_listManagedResources field.
-func (r *queryResolver) CoreListManagedResources(ctx context.Context, msvcName string, search *model.SearchManagedResources, pq *repos.CursorPagination) (*model.ManagedResourcePaginatedRecords, error) {
+func (r *queryResolver) CoreListManagedResources(ctx context.Context, search *model.SearchManagedResources, pq *repos.CursorPagination) (*model.ManagedResourcePaginatedRecords, error) {
 	cc, err := toConsoleContext(ctx)
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
 	filter := map[string]repos.MatchFilter{}
+
+	if search == nil {
+		return nil, errors.New("must specify search")
+	}
+
 	if search != nil {
 		if search.Text != nil {
 			filter["metadata.name"] = *search.Text
@@ -860,11 +875,19 @@ func (r *queryResolver) CoreListManagedResources(ctx context.Context, msvcName s
 		}
 
 		if search.ManagedServiceName != nil {
-			filter["spec.msvcRef.name"] = *search.ManagedServiceName
+			filter["managedServiceName"] = *search.ManagedServiceName
+		}
+
+		if search.EnvName != nil {
+			filter["environmentName"] = *search.EnvName
 		}
 	}
 
-	pmsvcs, err := r.Domain.ListManagedResources(newMresContext(cc, msvcName), filter, fn.DefaultIfNil(pq, repos.DefaultCursorPagination))
+	if search.EnvName == nil && search.ManagedServiceName == nil {
+		return nil, errors.New("either envName or managedServiceName must be specified")
+	}
+
+	pmsvcs, err := r.Domain.ListManagedResources(cc, filter, fn.DefaultIfNil(pq, repos.DefaultCursorPagination))
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
@@ -873,12 +896,12 @@ func (r *queryResolver) CoreListManagedResources(ctx context.Context, msvcName s
 }
 
 // CoreGetManagedResource is the resolver for the core_getManagedResource field.
-func (r *queryResolver) CoreGetManagedResource(ctx context.Context, msvcName string, name string) (*entities.ManagedResource, error) {
+func (r *queryResolver) CoreGetManagedResource(ctx context.Context, msvcName *string, envName *string, name string) (*entities.ManagedResource, error) {
 	cc, err := toConsoleContext(ctx)
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
-	return r.Domain.GetManagedResource(newMresContext(cc, msvcName), name)
+	return r.Domain.GetManagedResource(newMresContext(cc, msvcName, envName), name)
 }
 
 // CoreResyncManagedResource is the resolver for the core_resyncManagedResource field.
@@ -891,46 +914,6 @@ func (r *queryResolver) CoreResyncManagedResource(ctx context.Context, msvcName 
 		return false, errors.NewE(err)
 	}
 	return true, nil
-}
-
-// CoreListImportedManagedResources is the resolver for the core_listImportedManagedResources field.
-func (r *queryResolver) CoreListImportedManagedResources(ctx context.Context, envName string, search *model.SearchManagedResources, pq *repos.CursorPagination) (*model.ManagedResourcePaginatedRecords, error) {
-	cc, err := toConsoleContext(ctx)
-	if err != nil {
-		return nil, errors.NewE(err)
-	}
-	filter := map[string]repos.MatchFilter{}
-	if search != nil {
-		if search.Text != nil {
-			filter["metadata.name"] = *search.Text
-		}
-		if search.IsReady != nil {
-			filter["status.isReady"] = *search.IsReady
-		}
-		if search.MarkedForDeletion != nil {
-			filter["markedForDeletion"] = *search.MarkedForDeletion
-		}
-
-		if search.ManagedServiceName != nil {
-			filter["spec.msvcRef.name"] = *search.ManagedServiceName
-		}
-	}
-
-	pmsvcs, err := r.Domain.ListImportedManagedResources(newResourceContext(cc, envName), filter, fn.DefaultIfNil(pq, repos.DefaultCursorPagination))
-	if err != nil {
-		return nil, errors.NewE(err)
-	}
-
-	return fn.JsonConvertP[model.ManagedResourcePaginatedRecords](pmsvcs)
-}
-
-// CoreGetImportedManagedResource is the resolver for the core_getImportedManagedResource field.
-func (r *queryResolver) CoreGetImportedManagedResource(ctx context.Context, envName string, name string) (*entities.ManagedResource, error) {
-	cc, err := toConsoleContext(ctx)
-	if err != nil {
-		return nil, errors.NewE(err)
-	}
-	return r.Domain.GetImportedManagedResource(newResourceContext(cc, envName), name)
 }
 
 // CoreListVPNDevices is the resolver for the core_listVPNDevices field.

--- a/apps/console/internal/domain/api.go
+++ b/apps/console/internal/domain/api.go
@@ -45,7 +45,6 @@ func (c ConsoleContext) GetAccountName() string {
 
 type ResourceContext struct {
 	ConsoleContext
-	//ProjectName     string
 	EnvironmentName string
 }
 
@@ -71,7 +70,6 @@ func (m ManagedResourceContext) MresDBFilters() (*repos.Filter, error) {
 	}
 
 	return nil, errors.New("environment or managed service name is required")
-
 }
 
 func (r ResourceContext) DBFilters() repos.Filter {
@@ -168,7 +166,7 @@ type Domain interface {
 	GetEnvironment(ctx ConsoleContext, name string) (*entities.Environment, error)
 
 	CreateEnvironment(ctx ConsoleContext, env entities.Environment) (*entities.Environment, error)
-	CloneEnvironment(ctx ConsoleContext, sourceEnvName string, destinationEnvName string, displayName string, environmentRoutingMode crdsv1.EnvironmentRoutingMode) (*entities.Environment, error)
+	CloneEnvironment(ctx ConsoleContext, args CloneEnvironmentArgs) (*entities.Environment, error)
 	UpdateEnvironment(ctx ConsoleContext, env entities.Environment) (*entities.Environment, error)
 	DeleteEnvironment(ctx ConsoleContext, name string) error
 
@@ -287,13 +285,13 @@ type Domain interface {
 	ResyncImagePullSecret(ctx ConsoleContext, name string) error
 
 	GetEnvironmentResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error)
-	//GetProjectResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error)
+	// GetProjectResourceMapping(ctx ConsoleContext, resType entities.ResourceType, clusterName string, namespace string, name string) (*entities.ResourceMapping, error)
 
-	//ListProjectManagedServices(ctx ConsoleContext, projectName string, mf map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.ProjectManagedService], error)
-	//GetProjectManagedService(ctx ConsoleContext, projectName string, serviceName string) (*entities.ProjectManagedService, error)
-	//CreateProjectManagedService(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) (*entities.ProjectManagedService, error)
-	//UpdateProjectManagedService(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) (*entities.ProjectManagedService, error)
-	//DeleteProjectManagedService(ctx ConsoleContext, projectName string, name string) error
+	// ListProjectManagedServices(ctx ConsoleContext, projectName string, mf map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.ProjectManagedService], error)
+	// GetProjectManagedService(ctx ConsoleContext, projectName string, serviceName string) (*entities.ProjectManagedService, error)
+	// CreateProjectManagedService(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) (*entities.ProjectManagedService, error)
+	// UpdateProjectManagedService(ctx ConsoleContext, projectName string, service entities.ProjectManagedService) (*entities.ProjectManagedService, error)
+	// DeleteProjectManagedService(ctx ConsoleContext, projectName string, name string) error
 
 	//RestartProjectManagedService(ctx ConsoleContext, projectName string, name string) error
 	//

--- a/apps/console/internal/domain/mres.go
+++ b/apps/console/internal/domain/mres.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+
 	"github.com/kloudlite/api/apps/console/internal/entities"
 	fc "github.com/kloudlite/api/apps/console/internal/entities/field-constants"
 	iamT "github.com/kloudlite/api/apps/iam/types"
@@ -19,20 +20,15 @@ import (
 
 // query
 
-func (d *domain) ListManagedResources(ctx ManagedResourceContext, search map[string]repos.MatchFilter, pq repos.CursorPagination) (*repos.PaginatedRecord[*entities.ManagedResource], error) {
-	if err := d.canPerformActionInAccount(ctx.ConsoleContext, iamT.ListManagedResources); err != nil {
+func (d *domain) ListManagedResources(ctx ConsoleContext, search map[string]repos.MatchFilter, pq repos.CursorPagination) (*repos.PaginatedRecord[*entities.ManagedResource], error) {
+	if err := d.canPerformActionInAccount(ctx, iamT.ListManagedResources); err != nil {
 		return nil, errors.NewE(err)
 	}
-	filters := ctx.MresDBFilters().Add(fields.EnvironmentName, "")
 
-	return d.mresRepo.FindPaginated(ctx, d.mresRepo.MergeMatchFilters(filters, search), pq)
-}
-
-func (d *domain) ListImportedManagedResources(ctx ResourceContext, search map[string]repos.MatchFilter, pq repos.CursorPagination) (*repos.PaginatedRecord[*entities.ManagedResource], error) {
-	if err := d.canReadResourcesInEnvironment(ctx); err != nil {
-		return nil, errors.NewE(err)
+	filters := repos.Filter{
+		fields.AccountName: ctx.AccountName,
 	}
-	filters := ctx.DBFilters()
+
 	return d.mresRepo.FindPaginated(ctx, d.mresRepo.MergeMatchFilters(filters, search), pq)
 }
 
@@ -47,9 +43,14 @@ func (d *domain) listImportedMres(ctx ConsoleContext, mresName string) ([]*entit
 }
 
 func (d *domain) findMRes(ctx ManagedResourceContext, name string) (*entities.ManagedResource, error) {
+	filters, err := ctx.MresDBFilters()
+	if err != nil {
+		return nil, errors.NewE(err)
+	}
+
 	mres, err := d.mresRepo.FindOne(
 		ctx,
-		ctx.MresDBFilters().Add(fields.MetadataName, name),
+		filters.Add(fields.MetadataName, name),
 	)
 	if err != nil {
 		return nil, errors.NewE(err)
@@ -86,23 +87,26 @@ func (d *domain) GetManagedResource(ctx ManagedResourceContext, name string) (*e
 	return d.findMRes(ctx, name)
 }
 
-func (d *domain) GetImportedManagedResource(ctx ResourceContext, name string) (*entities.ManagedResource, error) {
-	if err := d.canReadResourcesInEnvironment(ctx); err != nil {
-		return nil, errors.NewE(err)
-	}
-	return d.findImportedMRes(ctx, name)
-}
+// func (d *domain) GetImportedManagedResource(ctx ResourceContext, name string) (*entities.ManagedResource, error) {
+// 	if err := d.canReadResourcesInEnvironment(ctx); err != nil {
+// 		return nil, errors.NewE(err)
+// 	}
+// 	return d.findImportedMRes(ctx, name)
+// }
 
 // GetManagedResourceOutputKVs implements Domain.
 func (d *domain) GetManagedResourceOutputKVs(ctx ManagedResourceContext, keyrefs []ManagedResourceKeyRef) ([]*ManagedResourceKeyValueRef, error) {
-	filters := ctx.MresDBFilters()
+	f, err := ctx.MresDBFilters()
+	if err != nil {
+		return nil, err
+	}
 
 	names := make([]any, 0, len(keyrefs))
 	for i := range keyrefs {
 		names = append(names, keyrefs[i].MresName)
 	}
 
-	filters = d.mresRepo.MergeMatchFilters(filters, map[string]repos.MatchFilter{
+	filters := d.mresRepo.MergeMatchFilters(*f, map[string]repos.MatchFilter{
 		fields.MetadataName: {
 			MatchType: repos.MatchTypeArray,
 			Array:     names,
@@ -144,8 +148,12 @@ func (d *domain) GetManagedResourceOutputKVs(ctx ManagedResourceContext, keyrefs
 
 // GetManagedResourceOutputKeys implements Domain.
 func (d *domain) GetManagedResourceOutputKeys(ctx ManagedResourceContext, name string) ([]string, error) {
-	filters := ctx.MresDBFilters()
-	filters.Add(fields.MetadataName, name)
+	// filters, err := ctx.MresDBFilters()
+	// if err != nil {
+	// 	return nil, errors.NewE(err)
+	// }
+	//
+	// filters.Add(fields.MetadataName, name)
 
 	mresSecret, err := d.findMRes(ctx, name)
 	if err != nil {
@@ -173,12 +181,16 @@ func (d *domain) CreateManagedResource(ctx ManagedResourceContext, mres entities
 		return nil, errors.NewE(err)
 	}
 
+	if ctx.ManagedServiceName == nil {
+		return nil, errors.Newf("managed service name is required")
+	}
+
 	msvcOut, err := d.infraClient.GetClusterManagedService(ctx, &infra.GetClusterManagedServiceIn{
 		UserId:      string(ctx.UserId),
 		UserName:    ctx.UserName,
 		UserEmail:   ctx.UserEmail,
 		AccountName: ctx.AccountName,
-		MsvcName:    ctx.ManagedServiceName,
+		MsvcName:    *ctx.ManagedServiceName,
 	})
 
 	if err != nil {
@@ -210,16 +222,21 @@ func (d *domain) CreateManagedResource(ctx ManagedResourceContext, mres entities
 
 	mres.AccountName = ctx.AccountName
 	mres.EnvironmentName = ""
-	mres.ManagedServiceName = ctx.ManagedServiceName
+	mres.ManagedServiceName = *ctx.ManagedServiceName
 	mres.IsImported = false
 	mres.ClusterName = msvcOut.ClusterName
 
 	return d.createAndApplyManagedResource(ctx, msvcOut.ClusterName, &mres)
 }
 
-func (d *domain) ImportManagedResource(ctx ManagedResourceContext, mresName string, envName string) (*entities.ManagedResource, error) {
+func (d *domain) ImportManagedResource(ctx ManagedResourceContext, mresName string) (*entities.ManagedResource, error) {
 
-	exMres, err := d.findMRes(ctx, mresName)
+	exMres, err := d.findMRes(ManagedResourceContext{
+		ConsoleContext:     ctx.ConsoleContext,
+		ManagedServiceName: ctx.ManagedServiceName,
+		EnvironmentName:    nil,
+	}, mresName)
+
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
@@ -228,7 +245,7 @@ func (d *domain) ImportManagedResource(ctx ManagedResourceContext, mresName stri
 		ctx,
 		repos.Filter{
 			fields.AccountName:        ctx.AccountName,
-			fields.EnvironmentName:    envName,
+			fields.EnvironmentName:    ctx.EnvironmentName,
 			fc.ManagedResourceMresRef: mresName,
 		},
 	)
@@ -251,11 +268,11 @@ func (d *domain) ImportManagedResource(ctx ManagedResourceContext, mresName stri
 	}
 	exMres.LastUpdatedBy = exMres.CreatedBy
 
-	exMres.EnvironmentName = envName
+	exMres.EnvironmentName = *ctx.EnvironmentName
 	exMres.IsImported = true
 	exMres.MresRef = mresName
 
-	return d.importAndApplyManagedResourceSecret(ctx, envName, exMres)
+	return d.importAndApplyManagedResourceSecret(ctx.ConsoleContext, *ctx.EnvironmentName, exMres)
 }
 
 func genMresResourceName(envName string, mresName string) string {
@@ -288,7 +305,7 @@ func (d *domain) createAndApplyManagedResource(ctx ManagedResourceContext, clust
 	return m, nil
 }
 
-func (d *domain) importAndApplyManagedResourceSecret(ctx ManagedResourceContext, envName string, mres *entities.ManagedResource) (*entities.ManagedResource, error) {
+func (d *domain) importAndApplyManagedResourceSecret(ctx ConsoleContext, envName string, mres *entities.ManagedResource) (*entities.ManagedResource, error) {
 	mres.Spec.ResourceNamePrefix = fn.New(genMresResourceName(envName, mres.Name))
 	mres.SyncStatus = t.GenSyncStatus(t.SyncActionApply, 0)
 
@@ -296,15 +313,20 @@ func (d *domain) importAndApplyManagedResourceSecret(ctx ManagedResourceContext,
 		return nil, errors.Newf("managed resource (%s), not ready yet, please try again", mres.Name)
 	}
 
+	ann := mres.SyncedOutputSecretRef.GetAnnotations()
+	for k, v := range types.SecretWatchingAnnotation {
+		ann[k] = v
+	}
+
 	secret := corev1.Secret{
 		TypeMeta: v1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s-creds", d.getEnvironmentTargetNamespace(envName), mres.Name),
+			Name:      mres.SyncedOutputSecretRef.Name,
 			Namespace: d.getEnvironmentTargetNamespace(envName),
 			Labels: map[string]string{
 				"kloudlite.io/mres.imported": "true",
 			},
-			Annotations: mres.SyncedOutputSecretRef.GetAnnotations(),
+			Annotations: ann,
 		},
 		Data: mres.SyncedOutputSecretRef.Data,
 	}
@@ -314,7 +336,7 @@ func (d *domain) importAndApplyManagedResourceSecret(ctx ManagedResourceContext,
 		return nil, errors.NewE(err)
 	}
 
-	d.resourceEventPublisher.PublishConsoleEvent(ctx.ConsoleContext, entities.ResourceTypeManagedResource, nImpMres.Name, PublishAdd)
+	d.resourceEventPublisher.PublishConsoleEvent(ctx, entities.ResourceTypeManagedResource, nImpMres.Name, PublishAdd)
 
 	if err := d.applyK8sResource(ctx, envName, &secret, 1); err != nil {
 		return nImpMres, errors.NewE(err)
@@ -363,9 +385,14 @@ func (d *domain) UpdateManagedResource(ctx ManagedResourceContext, mres entities
 			},
 		})
 
+	f, err := ctx.MresDBFilters()
+	if err != nil {
+		return nil, errors.NewE(err)
+	}
+
 	upMres, err := d.mresRepo.Patch(
 		ctx,
-		ctx.MresDBFilters().Add(fields.MetadataName, mres.Name),
+		f.Add(fields.MetadataName, mres.Name),
 		patchForUpdate,
 	)
 	if err != nil {
@@ -386,9 +413,14 @@ func (d *domain) DeleteManagedResource(ctx ManagedResourceContext, name string) 
 		return errors.NewE(err)
 	}
 
+	f, err := ctx.MresDBFilters()
+	if err != nil {
+		return errors.NewE(err)
+	}
+
 	umres, err := d.mresRepo.Patch(
 		ctx,
-		ctx.MresDBFilters().Add(fields.MetadataName, name),
+		f.Add(fields.MetadataName, name),
 		common.PatchForMarkDeletion(),
 	)
 	if err != nil {
@@ -414,10 +446,14 @@ func (d *domain) DeleteImportedManagedResource(ctx ResourceContext, mresName str
 		return errors.NewE(err)
 	}
 
+	if impMres.SyncedOutputSecretRef == nil {
+		return errors.Newf("managed resource (%s), not ready yet, please try again", mresName)
+	}
+
 	secret := corev1.Secret{
 		TypeMeta: v1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s-creds", d.getEnvironmentTargetNamespace(impMres.EnvironmentName), mresName),
+			Name:      impMres.SyncedOutputSecretRef.Name,
 			Namespace: d.getEnvironmentTargetNamespace(impMres.EnvironmentName),
 			Labels: map[string]string{
 				"kloudlite.io/mres.imported": "true",

--- a/apps/infra/Taskfile.yml
+++ b/apps/infra/Taskfile.yml
@@ -33,6 +33,7 @@ tasks:
           --struct github.com/kloudlite/api/apps/infra/internal/entities.Namespace
           --struct github.com/kloudlite/api/apps/infra/internal/entities.VolumeAttachment
           --struct github.com/kloudlite/api/pkg/repos.MatchFilter
+          --struct github.com/kloudlite/api/apps/infra/internal/domain.BYOKSetupInstruction
           --struct github.com/kloudlite/api/pkg/repos.CursorPagination
         > ./internal/app/_struct-to-graphql/main.go
       - |+

--- a/apps/infra/internal/app/gqlgen.yml
+++ b/apps/infra/internal/app/gqlgen.yml
@@ -145,7 +145,6 @@ models:
     model: github.com/kloudlite/api/pkg/repos.MatchFilter
   MatchFilterIn: *match-filter-model
 
-
   MatchFilterMatchType:
     model: github.com/kloudlite/api/pkg/repos.MatchType
 

--- a/apps/infra/internal/app/graph/generated/generated.go
+++ b/apps/infra/internal/app/graph/generated/generated.go
@@ -122,6 +122,11 @@ type ComplexityRoot struct {
 		TotalCount func(childComplexity int) int
 	}
 
+	BYOKSetupInstruction struct {
+		Command func(childComplexity int) int
+		Title   func(childComplexity int) int
+	}
+
 	CheckAwsAccessOutput struct {
 		InstallationURL func(childComplexity int) int
 		Result          func(childComplexity int) int
@@ -1587,7 +1592,7 @@ type QueryResolver interface {
 	InfraGetCluster(ctx context.Context, name string) (*entities.Cluster, error)
 	InfraListBYOKClusters(ctx context.Context, search *model.SearchCluster, pagination *repos.CursorPagination) (*model.BYOKClusterPaginatedRecords, error)
 	InfraGetBYOKCluster(ctx context.Context, name string) (*entities.BYOKCluster, error)
-	InfratGetBYOKClusterSetupInstructions(ctx context.Context, name string) ([]string, error)
+	InfratGetBYOKClusterSetupInstructions(ctx context.Context, name string) ([]*model.BYOKSetupInstruction, error)
 	InfraListGlobalVPNs(ctx context.Context, search *model.SearchGlobalVPNs, pagination *repos.CursorPagination) (*model.GlobalVPNPaginatedRecords, error)
 	InfraGetGlobalVpn(ctx context.Context, name string) (*entities.GlobalVPN, error)
 	InfraListGlobalVPNDevices(ctx context.Context, gvpn string, search *model.SearchGlobalVPNDevices, pagination *repos.CursorPagination) (*model.GlobalVPNDevicePaginatedRecords, error)
@@ -1853,6 +1858,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BYOKClusterPaginatedRecords.TotalCount(childComplexity), true
+
+	case "BYOKSetupInstruction.command":
+		if e.complexity.BYOKSetupInstruction.Command == nil {
+			break
+		}
+
+		return e.complexity.BYOKSetupInstruction.Command(childComplexity), true
+
+	case "BYOKSetupInstruction.title":
+		if e.complexity.BYOKSetupInstruction.Title == nil {
+			break
+		}
+
+		return e.complexity.BYOKSetupInstruction.Title(childComplexity), true
 
 	case "CheckAwsAccessOutput.installationUrl":
 		if e.complexity.CheckAwsAccessOutput.InstallationURL == nil {
@@ -7877,6 +7896,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputBYOKClusterIn,
+		ec.unmarshalInputBYOKSetupInstructionIn,
 		ec.unmarshalInputCloudProviderSecretIn,
 		ec.unmarshalInputClusterIn,
 		ec.unmarshalInputClusterManagedServiceIn,
@@ -8176,7 +8196,7 @@ type Query {
     # byok
     infra_listBYOKClusters(search: SearchCluster, pagination: CursorPaginationIn): BYOKClusterPaginatedRecords @isLoggedInAndVerified @hasAccount
     infra_getBYOKCluster(name: String!): BYOKCluster @isLoggedInAndVerified @hasAccount
-    infrat_getBYOKClusterSetupInstructions(name: String!): [String!] @isLoggedInAndVerified @hasAccount
+    infrat_getBYOKClusterSetupInstructions(name: String!): [BYOKSetupInstruction!] @isLoggedInAndVerified @hasAccount
 
     # global VPN
     infra_listGlobalVPNs(search: SearchGlobalVPNs, pagination: CursorPaginationIn): GlobalVPNPaginatedRecords @isLoggedInAndVerified @hasAccount
@@ -8318,6 +8338,17 @@ type BYOKClusterPaginatedRecords @shareable {
 input BYOKClusterIn {
   displayName: String!
   metadata: MetadataIn!
+}
+
+`, BuiltIn: false},
+	{Name: "../struct-to-graphql/byoksetupinstruction.graphqls", Input: `type BYOKSetupInstruction @shareable {
+  command: String!
+  title: String!
+}
+
+input BYOKSetupInstructionIn {
+  command: String!
+  title: String!
 }
 
 `, BuiltIn: false},
@@ -12761,6 +12792,94 @@ func (ec *executionContext) fieldContext_BYOKClusterPaginatedRecords_totalCount(
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BYOKSetupInstruction_command(ctx context.Context, field graphql.CollectedField, obj *model.BYOKSetupInstruction) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BYOKSetupInstruction_command(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Command, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BYOKSetupInstruction_command(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BYOKSetupInstruction",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BYOKSetupInstruction_title(ctx context.Context, field graphql.CollectedField, obj *model.BYOKSetupInstruction) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BYOKSetupInstruction_title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BYOKSetupInstruction_title(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BYOKSetupInstruction",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -49873,10 +49992,10 @@ func (ec *executionContext) _Query_infrat_getBYOKClusterSetupInstructions(ctx co
 		if tmp == nil {
 			return nil, nil
 		}
-		if data, ok := tmp.([]string); ok {
+		if data, ok := tmp.([]*model.BYOKSetupInstruction); ok {
 			return data, nil
 		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be []string`, tmp)
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/kloudlite/api/apps/infra/internal/app/graph/model.BYOKSetupInstruction`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -49885,9 +50004,9 @@ func (ec *executionContext) _Query_infrat_getBYOKClusterSetupInstructions(ctx co
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]*model.BYOKSetupInstruction)
 	fc.Result = res
-	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalOBYOKSetupInstruction2ᚕᚖgithubᚗcomᚋkloudliteᚋapiᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐBYOKSetupInstructionᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_infrat_getBYOKClusterSetupInstructions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -49897,7 +50016,13 @@ func (ec *executionContext) fieldContext_Query_infrat_getBYOKClusterSetupInstruc
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "command":
+				return ec.fieldContext_BYOKSetupInstruction_command(ctx, field)
+			case "title":
+				return ec.fieldContext_BYOKSetupInstruction_title(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type BYOKSetupInstruction", field.Name)
 		},
 	}
 	defer func() {
@@ -55338,6 +55463,44 @@ func (ec *executionContext) unmarshalInputBYOKClusterIn(ctx context.Context, obj
 			if err = ec.resolvers.BYOKClusterIn().Metadata(ctx, &it, data); err != nil {
 				return it, err
 			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputBYOKSetupInstructionIn(ctx context.Context, obj interface{}) (model.BYOKSetupInstructionIn, error) {
+	var it model.BYOKSetupInstructionIn
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"command", "title"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "command":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("command"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Command = data
+		case "title":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("title"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Title = data
 		}
 	}
 
@@ -61599,6 +61762,50 @@ func (ec *executionContext) _BYOKClusterPaginatedRecords(ctx context.Context, se
 			}
 		case "totalCount":
 			out.Values[i] = ec._BYOKClusterPaginatedRecords_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var bYOKSetupInstructionImplementors = []string{"BYOKSetupInstruction"}
+
+func (ec *executionContext) _BYOKSetupInstruction(ctx context.Context, sel ast.SelectionSet, obj *model.BYOKSetupInstruction) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, bYOKSetupInstructionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BYOKSetupInstruction")
+		case "command":
+			out.Values[i] = ec._BYOKSetupInstruction_command(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "title":
+			out.Values[i] = ec._BYOKSetupInstruction_title(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -73086,6 +73293,16 @@ func (ec *executionContext) unmarshalNBYOKClusterIn2githubᚗcomᚋkloudliteᚋa
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNBYOKSetupInstruction2ᚖgithubᚗcomᚋkloudliteᚋapiᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐBYOKSetupInstruction(ctx context.Context, sel ast.SelectionSet, v *model.BYOKSetupInstruction) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._BYOKSetupInstruction(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -75430,7 +75647,7 @@ func (ec *executionContext) marshalNfederation__Scope2ᚕᚕstringᚄ(ctx contex
 	return ret
 }
 
-func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (interface{}, error) {
+func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (any, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -75438,7 +75655,7 @@ func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v inter
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.SelectionSet, v interface{}) graphql.Marshaler {
+func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.SelectionSet, v any) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -75496,6 +75713,53 @@ func (ec *executionContext) marshalOBYOKClusterPaginatedRecords2ᚖgithubᚗcom�
 		return graphql.Null
 	}
 	return ec._BYOKClusterPaginatedRecords(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOBYOKSetupInstruction2ᚕᚖgithubᚗcomᚋkloudliteᚋapiᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐBYOKSetupInstructionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.BYOKSetupInstruction) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNBYOKSetupInstruction2ᚖgithubᚗcomᚋkloudliteᚋapiᚋappsᚋinfraᚋinternalᚋappᚋgraphᚋmodelᚐBYOKSetupInstruction(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/apps/infra/internal/app/graph/model/models_gen.go
+++ b/apps/infra/internal/app/graph/model/models_gen.go
@@ -24,6 +24,16 @@ type BYOKClusterPaginatedRecords struct {
 	TotalCount int                `json:"totalCount"`
 }
 
+type BYOKSetupInstruction struct {
+	Command string `json:"command"`
+	Title   string `json:"title"`
+}
+
+type BYOKSetupInstructionIn struct {
+	Command string `json:"command"`
+	Title   string `json:"title"`
+}
+
 type CheckAwsAccessOutput struct {
 	Result          bool    `json:"result"`
 	InstallationURL *string `json:"installationUrl,omitempty"`

--- a/apps/infra/internal/app/graph/schema.graphqls
+++ b/apps/infra/internal/app/graph/schema.graphqls
@@ -91,7 +91,7 @@ type Query {
     # byok
     infra_listBYOKClusters(search: SearchCluster, pagination: CursorPaginationIn): BYOKClusterPaginatedRecords @isLoggedInAndVerified @hasAccount
     infra_getBYOKCluster(name: String!): BYOKCluster @isLoggedInAndVerified @hasAccount
-    infrat_getBYOKClusterSetupInstructions(name: String!): [String!] @isLoggedInAndVerified @hasAccount
+    infrat_getBYOKClusterSetupInstructions(name: String!): [BYOKSetupInstruction!] @isLoggedInAndVerified @hasAccount
 
     # global VPN
     infra_listGlobalVPNs(search: SearchGlobalVPNs, pagination: CursorPaginationIn): GlobalVPNPaginatedRecords @isLoggedInAndVerified @hasAccount

--- a/apps/infra/internal/app/graph/schema.resolvers.go
+++ b/apps/infra/internal/app/graph/schema.resolvers.go
@@ -490,13 +490,26 @@ func (r *queryResolver) InfraGetBYOKCluster(ctx context.Context, name string) (*
 }
 
 // InfratGetBYOKClusterSetupInstructions is the resolver for the infrat_getBYOKClusterSetupInstructions field.
-func (r *queryResolver) InfratGetBYOKClusterSetupInstructions(ctx context.Context, name string) ([]string, error) {
+func (r *queryResolver) InfratGetBYOKClusterSetupInstructions(ctx context.Context, name string) ([]*model.BYOKSetupInstruction, error) {
 	ictx, err := toInfraContext(ctx)
 	if err != nil {
 		return nil, errors.NewE(err)
 	}
 
-	return r.Domain.GetBYOKClusterSetupInstructions(ictx, name)
+	bcsi, err := r.Domain.GetBYOKClusterSetupInstructions(ictx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make([]*model.BYOKSetupInstruction, len(bcsi))
+	for i, v := range bcsi {
+		m[i], err  = fn.JsonConvertP[model.BYOKSetupInstruction](v)
+if err != nil {
+        return nil, err
+      }
+	}
+
+	return m, nil
 }
 
 // InfraListGlobalVPNs is the resolver for the infra_listGlobalVPNs field.

--- a/apps/infra/internal/app/graph/struct-to-graphql/byoksetupinstruction.graphqls
+++ b/apps/infra/internal/app/graph/struct-to-graphql/byoksetupinstruction.graphqls
@@ -1,0 +1,10 @@
+type BYOKSetupInstruction @shareable {
+  command: String!
+  title: String!
+}
+
+input BYOKSetupInstructionIn {
+  command: String!
+  title: String!
+}
+

--- a/apps/infra/internal/domain/api.go
+++ b/apps/infra/internal/domain/api.go
@@ -77,7 +77,7 @@ type Domain interface {
 	UpdateBYOKCluster(ctx InfraContext, clusterName string, displayName string) (*entities.BYOKCluster, error)
 	ListBYOKCluster(ctx InfraContext, search map[string]repos.MatchFilter, pagination repos.CursorPagination) (*repos.PaginatedRecord[*entities.BYOKCluster], error)
 	GetBYOKCluster(ctx InfraContext, name string) (*entities.BYOKCluster, error)
-	GetBYOKClusterSetupInstructions(ctx InfraContext, name string) ([]string, error)
+	GetBYOKClusterSetupInstructions(ctx InfraContext, name string) ([]BYOKSetupInstruction, error)
 
 	DeleteBYOKCluster(ctx InfraContext, name string) error
 	UpsertBYOKClusterKubeconfig(ctx InfraContext, clusterName string, kubeconfig []byte) error

--- a/apps/infra/internal/domain/byok-clusters.go
+++ b/apps/infra/internal/domain/byok-clusters.go
@@ -166,16 +166,22 @@ func (d *domain) GetBYOKCluster(ctx InfraContext, name string) (*entities.BYOKCl
 	return c, nil
 }
 
-func (d *domain) GetBYOKClusterSetupInstructions(ctx InfraContext, name string) ([]string, error) {
+type BYOKSetupInstruction struct {
+	Title   string `json:"title"`
+	Command string `json:"command"`
+}
+
+func (d *domain) GetBYOKClusterSetupInstructions(ctx InfraContext, name string) ([]BYOKSetupInstruction, error) {
 	cluster, err := d.findBYOKCluster(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 
-	return []string{
-		`helm repo add kloudlite https://kloudlite.github.io/helm-charts`,
-		`helm repo update kloudlite`,
-		fmt.Sprintf(`helm upgrade --install kloudlite --namespace kloudlite --create-namespace kloudlite/kloudlite-agent --version %s --set accountName="%s" --set clusterName="%s" --set clusterToken="%s" --set messageOfficeGRPCAddr="%s" --set byok.enabled=true --set helmCharts.ingressNginx.enabled=true --set helmCharts.certManager.enabled=true`, d.env.KloudliteRelease, ctx.AccountName, name, cluster.ClusterToken, d.env.MessageOfficeExternalGrpcAddr),
+	return []BYOKSetupInstruction{
+		{Title: "Add Helm Repo", Command: "helm repo add kloudlite https://kloudlite.github.io/helm-charts"},
+		{Title: "Update Kloudlite Repo", Command: "helm repo update kloudlite"},
+		{Title: "Install kloudlite CRDs", Command: fmt.Sprintf("kubectl apply -f https://github.com/kloudlite/helm-charts/releases/download/%s/crds-all.yml", d.env.KloudliteRelease)},
+		{Title: "Install Kloudlite Agent", Command: fmt.Sprintf(`helm upgrade --install kloudlite --namespace kloudlite --create-namespace kloudlite/kloudlite-agent --version %s --set accountName="%s" --set clusterName="%s" --set clusterToken="%s" --set messageOfficeGRPCAddr="%s" --set byok.enabled=true --set helmCharts.ingressNginx.enabled=true --set helmCharts.certManager.enabled=true`, d.env.KloudliteRelease, ctx.AccountName, name, cluster.ClusterToken, d.env.MessageOfficeExternalGrpcAddr)},
 	}, nil
 }
 

--- a/apps/infra/internal/entities/global-vpn-device.go
+++ b/apps/infra/internal/entities/global-vpn-device.go
@@ -45,6 +45,7 @@ var GlobalVPNDeviceIndices = []repos.IndexField{
 	},
 	{
 		Field: []repos.IndexKey{
+			{Key: fc.AccountName, Value: repos.IndexAsc},
 			{Key: fc.GlobalVPNDeviceGlobalVPNName, Value: repos.IndexAsc},
 			{Key: fc.GlobalVPNDeviceIpAddr, Value: repos.IndexAsc},
 		},

--- a/apps/tenant-agent/Taskfile.yml
+++ b/apps/tenant-agent/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
     cmds:
       - task: go:build 
         vars: 
-          Out: ./bin/{{.app}}-${GOARCH:-{{.GOARCH}}}
+          Out: ./bin/{{.app}}-${GOARCH:-$(go env GOARCH)}
 
   local:build-and-push:
     preconditions:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the managed resource context to support both `managedServiceName` and `environmentName`, introduces new features for specifying `clusterName` in environment cloning, and adds structured BYOK cluster setup instructions. It also removes deprecated queries and improves error handling and validation.

* **New Features**:
    - Introduced support for specifying `clusterName` in the `CoreCloneEnvironment` mutation.
    - Added `envName` as an optional filter for managed resource queries.
    - Introduced `BYOKSetupInstruction` type and related GraphQL schema changes for better structuring of BYOK cluster setup instructions.
* **Enhancements**:
    - Refactored managed resource context to support both `managedServiceName` and `environmentName`.
    - Updated `CoreGetManagedResouceOutputKeyValues` and `CoreGetManagedResouceOutputKeys` to accept optional `envName` and `msvcName` parameters.
    - Improved error handling and validation for managed resource operations.
* **Chores**:
    - Removed deprecated `CoreListImportedManagedResources` and `CoreGetImportedManagedResource` queries.
    - Updated Taskfile.yml in `tenant-agent` to fix the output path for the build command.

<!-- Generated by sourcery-ai[bot]: end summary -->