### PR TITLE
fix(clone-environment): also clones imported managed resources

### DIFF
--- a/apps/console/internal/app/dns-server.go
+++ b/apps/console/internal/app/dns-server.go
@@ -66,9 +66,14 @@ func (h *dnsHandler) resolver(ctx context.Context, domain string, qtype uint16) 
 	m.RecursionDesired = true
 
 	question := m.Question[0]
-	sp := strings.SplitN(question.Name, fmt.Sprintf(".%s", h.kloudliteDNSSuffix), 2)
+	sp := strings.SplitN(strings.ToLower(question.Name), fmt.Sprintf(".%s", h.kloudliteDNSSuffix), 2)
 	if len(sp) < 2 {
 		return nil, fmt.Errorf("failed to split into 2 over .%s", h.kloudliteDNSSuffix)
+	}
+
+	if strings.HasSuffix(sp[0], ".local") {
+		// INFO: domains ending with .local are supposed to be reserved for local machine only
+		return h.newRR(question.Name, 7*24*60*60, "127.0.0.1")
 	}
 
 	comps := strings.Split(sp[0], ".")

--- a/apps/console/internal/entities/secret.go
+++ b/apps/console/internal/entities/secret.go
@@ -27,10 +27,10 @@ type Secret struct {
 }
 
 type SecretCreatedFor struct {
-	RefId        repos.ID `json:"refId"`
-	ResourceType ResourceType   `json:"resourceType"`
-	Name         string   `json:"name"`
-	Namespace    string   `json:"namespace"`
+	RefId        repos.ID     `json:"refId"`
+	ResourceType ResourceType `json:"resourceType"`
+	Name         string       `json:"name"`
+	Namespace    string       `json:"namespace"`
 }
 
 func (s *Secret) GetDisplayName() string {

--- a/apps/iam/main.go
+++ b/apps/iam/main.go
@@ -28,6 +28,7 @@ func main() {
 		fx.Provide(func() logging.Logger {
 			return logger
 		}),
+
 		fx.Provide(func() (*env.Env, error) {
 			return env.LoadEnv()
 		}),
@@ -45,5 +46,4 @@ func main() {
 
 	common.PrintReadyBanner()
 	<-app.Done()
-
 }

--- a/pkg/logging/slog-logger.go
+++ b/pkg/logging/slog-logger.go
@@ -21,6 +21,11 @@ type SlogOptions struct {
 }
 
 func NewSlogLogger(opts SlogOptions) *slog.Logger {
+	// INFO: force colored output, otherwise honor the env-var `CLICOLOR_FORCE`
+	if _, ok := os.LookupEnv("CLICOLOR_FORCE"); !ok {
+		os.Setenv("CLICOLOR_FORCE", "1")
+	}
+
 	if opts.Writer == nil {
 		opts.Writer = os.Stderr
 	}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix cloning of imported managed resources during environment cloning. Refactor import managed resource logic into a separate function. Enhance DNS resolver to handle case-insensitive domain names and reserve `.local` domains. Ensure logger forces colored output unless overridden by environment variable.

Bug Fixes:
- Fix issue where imported managed resources were not cloned during environment cloning.

Enhancements:
- Refactor the import managed resource logic into a new function `createAndApplyImportedManagedResource` for better code organization.
- Ensure DNS resolver handles domain names in a case-insensitive manner and reserves `.local` domains for local machine use.
- Force colored output in the logger unless the `CLICOLOR_FORCE` environment variable is set.

<!-- Generated by sourcery-ai[bot]: end summary -->