### PR TITLE
fix: cleans up service binding dns records, when synced without

### DIFF
--- a/apps/console/internal/app/dns-server.go
+++ b/apps/console/internal/app/dns-server.go
@@ -73,11 +73,13 @@ func (h *dnsHandler) resolver(ctx context.Context, domain string, qtype uint16) 
 	question := m.Question[0]
 	sp := strings.SplitN(strings.ToLower(question.Name), fmt.Sprintf(".%s", h.kloudliteDNSSuffix), 2)
 	if len(sp) < 2 {
+		h.logger.Debug("INVALID DNS QUERY", "domain", domain, "qtype", qtype)
 		return nil, errInvalidDNSQuery
 	}
 
 	if strings.HasSuffix(sp[0], ".local") {
 		// INFO: domains ending with .local are supposed to be reserved for local machine only
+		h.logger.Debug("LOCAL DOMAIN", "domain", domain, "qtype", qtype)
 		return h.newRR(question.Name, 7*24*60*60, "127.0.0.1")
 	}
 
@@ -87,6 +89,7 @@ func (h *dnsHandler) resolver(ctx context.Context, domain string, qtype uint16) 
 
 	sb, err := h.serviceBindingDomain.FindServiceBindingByHostname(ctx, accountName, hostname)
 	if err != nil {
+		h.logger.Debug("failed to find service binding, got", "err", err, "domain", domain, "qtype", qtype)
 		return nil, errors.NewEf(err, "failed to find service binding")
 	}
 

--- a/apps/console/main.go
+++ b/apps/console/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/kloudlite/api/pkg/errors"
@@ -28,7 +27,7 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "--debug")
 	flag.Parse()
 
-	logger, err := logging.New(&logging.Options{Name: "console", ShowDebugLog: isDev || strings.ToLower(os.Getenv("LOG_LEVEL")) == "debug"})
+	logger, err := logging.New(&logging.Options{Name: "console", ShowDebugLog: debug})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Resolves kloudlite/kloudlite#284

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the cleanup of DNS records for service bindings when the hostname is missing or the service IP is nil, and enhance logging in the DNS resolver for better debugging.

Bug Fixes:
- Fix the cleanup of DNS records for service bindings when the hostname is not specified or the service IP is nil.

Enhancements:
- Add debug logging for invalid DNS queries and local domain handling in the DNS resolver.
- Improve logging for failed service binding lookups in the DNS resolver.

<!-- Generated by sourcery-ai[bot]: end summary -->