### PR TITLE
feat: text search on image name

### DIFF
--- a/apps/console/internal/app/graph/schema.resolvers.go
+++ b/apps/console/internal/app/graph/schema.resolvers.go
@@ -7,8 +7,9 @@ package graph
 import (
 	"context"
 	"fmt"
-	"github.com/kloudlite/api/pkg/errors"
 	"time"
+
+	"github.com/kloudlite/api/pkg/errors"
 
 	"github.com/kloudlite/api/apps/console/internal/app/graph/generated"
 	"github.com/kloudlite/api/apps/console/internal/app/graph/model"
@@ -1072,5 +1073,7 @@ func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResol
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
-type mutationResolver struct{ *Resolver }
-type queryResolver struct{ *Resolver }
+type (
+	mutationResolver struct{ *Resolver }
+	queryResolver    struct{ *Resolver }
+)

--- a/apps/console/internal/domain/registry-image.go
+++ b/apps/console/internal/domain/registry-image.go
@@ -105,6 +105,14 @@ func (d *domain) SearchRegistryImages(ctx ConsoleContext, query string) ([]*enti
 		return nil, errors.NewE(err)
 	}
 
+	if query == "" {
+		return d.registryImageRepo.Find(ctx, repos.Query{
+			Filter: repos.Filter{},
+			Sort:   map[string]any{"_id": -1},
+			Limit:  fn.New(int64(10)),
+		})
+	}
+
 	filters := repos.Filter{
 		fields.AccountName: ctx.AccountName,
 		"$text":            map[string]any{"$search": query},

--- a/apps/console/internal/entities/registry-image.go
+++ b/apps/console/internal/entities/registry-image.go
@@ -39,6 +39,7 @@ var RegistryImageIndexes = []repos.IndexField{
 		Field: []repos.IndexKey{
 			{Key: fields.AccountName, Value: repos.IndexAsc},
 			{Key: fc.Metadata, Value: repos.IndexAsc, IsText: true},
+			{Key: fc.RegistryImageImageName, Value: repos.IndexAsc, IsText: true},
 		},
 	},
 }


### PR DESCRIPTION
- search image registries, with empty query, returns 10 recent images

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add text search capability for image names in the registry and enhance the search functionality to return the 10 most recent images when no query is provided.

New Features:
- Implement text search functionality on image names in the registry.

Enhancements:
- Return the 10 most recent images when the search query is empty.

<!-- Generated by sourcery-ai[bot]: end summary -->