### PR TITLE
Fix/gvpn gateway allowed ips

### DIFF
--- a/apps/console/internal/app/graph/schema.graphqls
+++ b/apps/console/internal/app/graph/schema.graphqls
@@ -107,6 +107,8 @@ input CoreSearchVPNDevices {
 type Query {
 	core_checkNameAvailability(envName: String, msvcName: String ,resType: ConsoleResType!, name: String!): ConsoleCheckNameAvailabilityOutput! @isLoggedIn @hasAccount
 
+  core_getDNSHostSuffix: String!
+
 	core_listEnvironments(search: SearchEnvironments, pq: CursorPaginationIn): EnvironmentPaginatedRecords @isLoggedInAndVerified @hasAccount
 	core_getEnvironment(name: String!): Environment @isLoggedInAndVerified @hasAccount
 	core_resyncEnvironment(name: String!): Boolean! @isLoggedInAndVerified @hasAccount

--- a/apps/console/internal/app/graph/schema.resolvers.go
+++ b/apps/console/internal/app/graph/schema.resolvers.go
@@ -453,6 +453,11 @@ func (r *queryResolver) CoreCheckNameAvailability(ctx context.Context, envName *
 	return r.Domain.CheckNameAvailability(ctx, cc.AccountName, envName, msvcName, resType, name)
 }
 
+// CoreGetDNSHostSuffix is the resolver for the core_getDNSHostSuffix field.
+func (r *queryResolver) CoreGetDNSHostSuffix(ctx context.Context) (string, error) {
+	return r.EnvVars.KloudliteDNSSuffix, nil
+}
+
 // CoreListEnvironments is the resolver for the core_listEnvironments field.
 func (r *queryResolver) CoreListEnvironments(ctx context.Context, search *model.SearchEnvironments, pq *repos.CursorPagination) (*model.EnvironmentPaginatedRecords, error) {
 	cc, err := toConsoleContext(ctx)

--- a/apps/infra/internal/domain/global-vpn-cluster-connection.go
+++ b/apps/infra/internal/domain/global-vpn-cluster-connection.go
@@ -96,7 +96,7 @@ func (d *domain) listGlobalVPNConnections(ctx InfraContext, vpnName string) ([]*
 
 func hashPeer(peer networkingv1.Peer) string {
 	sort.Strings(peer.AllowedIPs)
-	return fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s:%s:%s", peer.IP, peer.PublicKey, fn.DefaultIfNil(peer.PublicEndpoint), fn.DefaultIfNil(peer.DNSSuffix), strings.Join(peer.AllowedIPs, ",")))))
+	return fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s:%s:%s", fn.DefaultIfNil(peer.IP, ""), peer.PublicKey, fn.DefaultIfNil(peer.PublicEndpoint), fn.DefaultIfNil(peer.DNSSuffix), strings.Join(peer.AllowedIPs, ",")))))
 }
 
 func hashPeers(peers []networkingv1.Peer) string {

--- a/apps/infra/internal/domain/global-vpn-devices.go
+++ b/apps/infra/internal/domain/global-vpn-devices.go
@@ -237,7 +237,10 @@ func (d *domain) buildPeerFromGlobalVPNDevice(_ InfraContext, gvpn *entities.Glo
 
 	if device.IPAddr == gvpn.KloudliteGatewayDevice.IPAddr {
 		// FIXME: this should not be used
-		allowedIPs = append(allowedIPs, gvpn.NonClusterUseAllowedIPs...)
+		// allowedIPs = append(allowedIPs, gvpn.NonClusterUseAllowedIPs...)
+
+		// NOTE: i don't even remember what is the use case of non-cluster-use allowed IPs
+		allowedIPs = append(allowedIPs, "100.64.0.0/10")
 		// allowedIPs = append(allowedIPs, privateCIDRs...)
 	}
 


### PR DESCRIPTION
Resolves kloudlite/kloudlite#295

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the allowed IPs configuration in global VPN devices and add a new resolver for retrieving DNS host suffix.

Bug Fixes:
- Fix the handling of allowed IPs in the global VPN device configuration by replacing the use of non-cluster-use allowed IPs with a specific IP range.

Enhancements:
- Add a new resolver function CoreGetDNSHostSuffix to retrieve the DNS host suffix from environment variables.

<!-- Generated by sourcery-ai[bot]: end summary -->